### PR TITLE
Changed: Table toolbar shouldn't be displayed when whole table is selected.

### DIFF
--- a/src/tabletoolbar.js
+++ b/src/tabletoolbar.js
@@ -112,9 +112,9 @@ export default class TableToolbar extends Plugin {
 		if ( !editor.ui.focusTracker.isFocused ) {
 			this._hideToolbar();
 		} else {
-			const viewSeleciton = editor.editing.view.document.selection;
+			const viewSelection = editor.editing.view.document.selection;
 
-			if ( isTableWidgetSelected( viewSeleciton ) || isTableContentSelected( viewSeleciton ) ) {
+			if ( isTableContentSelected( viewSelection ) ) {
 				this._showToolbar();
 			} else {
 				this._hideToolbar();

--- a/src/ui/utils.js
+++ b/src/ui/utils.js
@@ -9,7 +9,6 @@
 
 import BalloonPanelView from '@ckeditor/ckeditor5-ui/src/panel/balloon/balloonpanelview';
 import { getParentTable } from '../commands/utils';
-import { isTableWidgetSelected } from '../utils';
 
 /**
  * A helper utility that positions the
@@ -36,13 +35,8 @@ export function getBalloonPositionData( editor ) {
 	const editingView = editor.editing.view;
 	const defaultPositions = BalloonPanelView.defaultPositions;
 	const viewSelection = editingView.document.selection;
-	let parentTable;
 
-	if ( isTableWidgetSelected( viewSelection ) ) {
-		parentTable = viewSelection.getSelectedElement();
-	} else {
-		parentTable = getParentTable( viewSelection.getFirstPosition() );
-	}
+	const parentTable = getParentTable( viewSelection.getFirstPosition() );
 
 	return {
 		target: editingView.domConverter.viewToDom( parentTable ),

--- a/tests/tabletoolbar.js
+++ b/tests/tabletoolbar.js
@@ -117,10 +117,10 @@ describe( 'TableToolbar', () => {
 			editor.ui.focusTracker.isFocused = true;
 		} );
 
-		it( 'should show the toolbar on render when the table is selected', () => {
+		it( 'should not show the toolbar on render when the table is selected', () => {
 			setData( model, '<paragraph>foo</paragraph>[<table><tableRow><tableCell></tableCell></tableRow></table>]' );
 
-			expect( balloon.visibleView ).to.equal( toolbar );
+			expect( balloon.visibleView ).to.be.null;
 		} );
 
 		it( 'should show the toolbar on render when the table content is selected', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Table toolbar shouldn't be displayed when whole table is selected. Closes #36.

---

### Additional information

* none - as agreed in #36 currently all the table toolbar contents are disabled so no need to display it
