### PR TITLE
Fix: Error thrown when navigating into the table insertion panel using the keyboard.

### DIFF
--- a/src/ui/inserttableview.js
+++ b/src/ui/inserttableview.js
@@ -17,6 +17,7 @@ import './../../theme/inserttable.css';
  * It renders a 10x10 grid to choose inserted table size.
  *
  * @extends module:ui/view~View
+ * @implements module:ui/dropdown/dropdownpanelfocusable~DropdownPanelFocusable
  */
 export default class InsertTableView extends View {
 	/**
@@ -119,6 +120,22 @@ export default class InsertTableView extends View {
 		this.on( 'change:rows', () => {
 			this._highlightGridBoxes();
 		} );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	focus() {
+		// The dropdown panel expects DropdownPanelFocusable interface on views passed to dropdown panel. See #30.
+		// The method should be implemented while working on keyboard support for this view. See #22.
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	focusLast() {
+		// The dropdown panel expects DropdownPanelFocusable interface on views passed to dropdown panel. See #30.
+		// The method should be implemented while working on keyboard support for this view. See #22.
 	}
 
 	/**

--- a/tests/ui/inserttableview.js
+++ b/tests/ui/inserttableview.js
@@ -54,6 +54,11 @@ describe( 'InsertTableView', () => {
 			expect( view.items ).to.have.length( 100 );
 		} );
 
+		it( 'should not throw error for DropdownPanelFocusable interface methods', () => {
+			expect( () => view.focus() ).to.not.throw();
+			expect( () => view.focusLast() ).to.not.throw();
+		} );
+
 		describe( 'view#items bindings', () => {
 			it( 'updates view#height & view#width on "over" event', () => {
 				const boxView = view.items.get( 0 );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Error thrown when navigating into the table insertion panel using the keyboard. Closes #30.

---

### Additional information

* I've simply removed the error by adding missing dummy methods. The core issue is that this view does not have keyboard support (#22). So I'd fix the error here and implement #22 with proper keyboard support either before or after the initial release.
