### PR TITLE
Fix: [ClassicEditor] Creating table fails when the toolbar is sticky.

### DIFF
--- a/src/ui/inserttableview.js
+++ b/src/ui/inserttableview.js
@@ -88,6 +88,10 @@ export default class InsertTableView extends View {
 			],
 
 			on: {
+				mousedown: bind.to( evt => {
+					evt.preventDefault();
+				} ),
+
 				click: bind.to( () => {
 					this.fire( 'execute' );
 				} )

--- a/tests/ui/inserttableview.js
+++ b/tests/ui/inserttableview.js
@@ -87,6 +87,12 @@ describe( 'InsertTableView', () => {
 				expect( view.label ).to.equal( '3 x 7' );
 			} );
 
+			it( 'mousedown event should be prevented', () => {
+				const ret = view.element.dispatchEvent( new Event( 'mousedown', { cancelable: true } ) );
+
+				expect( ret ).to.false;
+			} );
+
 			describe( 'DOM', () => {
 				it( 'fires execute on "click" event', () => {
 					const spy = sinon.spy();


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: [ClassicEditor] Creating table fails when the toolbar is sticky. Closes #37.
