### PR TITLE
Fix: Broken table layout when merging cell with a cell above.

### DIFF
--- a/src/commands/mergecellcommand.js
+++ b/src/commands/mergecellcommand.js
@@ -158,16 +158,26 @@ function getVerticalCell( tableCell, direction ) {
 		return;
 	}
 
-	const rowspan = parseInt( tableCell.getAttribute( 'rowspan' ) || 1 );
-	const mergeRow = direction == 'down' ? rowIndex + rowspan : rowIndex;
+	const currentCellRowSpan = parseInt( tableCell.getAttribute( 'rowspan' ) || 1 );
+	const rowOfCellToMerge = direction == 'down' ? rowIndex + currentCellRowSpan : rowIndex;
 
-	const tableMap = [ ...new TableWalker( table, { endRow: mergeRow } ) ];
+	const tableMap = [ ...new TableWalker( table, { endRow: rowOfCellToMerge } ) ];
 
 	const currentCellData = tableMap.find( value => value.cell === tableCell );
 	const mergeColumn = currentCellData.column;
 
-	const cellToMergeData = tableMap.find( ( { row, column } ) => {
-		return column === mergeColumn && ( direction == 'down' ? mergeRow === row : mergeRow === rowspan + row );
+	const cellToMergeData = tableMap.find( ( { row, rowspan, column } ) => {
+		if ( column !== mergeColumn ) {
+			return false;
+		}
+
+		if ( direction == 'down' ) {
+			// If merging a cell below the mergeRow is already calculated.
+			return row === rowOfCellToMerge;
+		} else {
+			// If merging a cell above calculate if it spans to mergeRow.
+			return rowOfCellToMerge === row + rowspan;
+		}
 	} );
 
 	return cellToMergeData && cellToMergeData.cell;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Broken table layout when merging cell with a cell above. Closes #43.

---

### Additional information
- I've refactored the code a bit as the `rowspan` in `tableMap.find()` callback was taken from wrong scope.
