### PR TITLE
t/2: The MVP of table content styles

### DIFF
--- a/src/table.js
+++ b/src/table.js
@@ -13,6 +13,8 @@ import TableEditing from './tableediting';
 import TableUI from './tableui';
 import Widget from '@ckeditor/ckeditor5-widget/src/widget';
 
+import '../theme/table.css';
+
 /**
  * The table plugin.
  *

--- a/src/tableediting.js
+++ b/src/tableediting.js
@@ -33,7 +33,7 @@ import SetHeaderColumnCommand from './commands/setheadercolumncommand';
 import { getParentTable } from './commands/utils';
 import TableUtils from './tableutils';
 
-import './../theme/table.css';
+import '../theme/tableediting.css';
 
 /**
  * The table editing feature.

--- a/tests/manual/table.html
+++ b/tests/manual/table.html
@@ -1,28 +1,7 @@
 <style>
-
-	table {
-		border-collapse: collapse;
-		border-spacing: 0;
-		border-color: hsl(0,0%,87%);
-	}
-
-	table, th, td {
-		padding: 5px;
-		border: 1px inset hsl(0,0%,87%);
-	}
-
-	table th,
-	table td {
-		min-width: 1em;
-	}
-
-	table th {
-		background: hsl(0,0%,96%);
-		font-weight: bold;
-	}
-
-	table thead th {
-		background: hsl(0,0%,90%);
+	body {
+		font-family: Helvetica, Arial, sans-serif;
+		font-size: 14px;
 	}
 </style>
 
@@ -47,7 +26,7 @@
 		</thead>
 		<tbody>
 		<tr>
-			<th colspan="2" rowspan="4" scope="rowgroup">Terrestial planets</th>
+			<th colspan="2" rowspan="4" scope="rowgroup">Terrestrial planets</th>
 			<th scope="row">Mercury</th>
 			<td>0.330</td>
 			<td>4,879</td>

--- a/theme/table.css
+++ b/theme/table.css
@@ -3,24 +3,30 @@
  * For licensing, see LICENSE.md.
  */
 
-.ck table.ck-widget th.ck-editor__nested-editable {
-	border-color: inherit;
-	border-style: inset;
-}
+.ck.ck-content table {
+	/* Give the table some air and center it horizontally */
+	margin: 1em auto;
 
-.ck table.ck-widget td.ck-editor__nested-editable {
-	border-color: inherit;
-	border-style: inset;
-}
+	/* The table cells should have slight borders */
+	border-collapse: collapse;
+	border-spacing: 0;
 
-.ck table.ck-widget td.ck-editor__nested-editable.ck-editor__nested-editable_focused,
-.ck table.ck-widget td.ck-editor__nested-editable:focus {
-	background-color: inherit;
-	color: inherit;
-}
+	/* The outer border of the table should be slightly darker than the inner lines. */
+	&:not(:hover) {
+		outline: 1px solid hsl(0, 0%, 70%);
+		outline-offset: -1px;
+	}
 
-.ck table.ck-widget th.ck-editor__nested-editable.ck-editor__nested-editable_focused,
-.ck table.ck-widget th.ck-editor__nested-editable:focus {
-	background-color: inherit;
-	color: inherit;
+	& td,
+	& th {
+		min-width: 2em;
+		padding: .4em;
+		text-align: center;
+		border-color: hsl(0, 0%, 85%);
+	}
+
+	& th {
+		font-weight: bold;
+		background: hsl(0, 0%, 98%);
+	}
 }

--- a/theme/tableediting.css
+++ b/theme/tableediting.css
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/*
+ * Note: This file should contain the wireframe styles only. But since there are no such styles,
+ * it acts as a message to the builder telling that it should look for the corresponding styles
+ * **in the theme** when compiling the editor.
+ */


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: The MVP of table content styles. Moved styles related to the editing to ckeditor5-theme-lark (see #2).

---

### Additional information

* Requires: https://github.com/ckeditor/ckeditor5-theme-lark/pull/176

### About

**Note:** It's an MVP which means we may still improve the styles in the future (doesn't close #2).

* Centered layout similar to default image styles,
* By default the table is **not** full-width because it looks odd when it's 2x2 and spans 1000px
* `min-width` of the table cell + `padding` to make an empty table look more user–friendly; easier to place the caret inside,
* Bold text in header cells to stress their meaning,
* A very slight background of header cells to avoid situations when the body cells have bold text and there's no obvious boundary between the header and the content (also when there's no content at all),
* A very slight background of a selected cell which works with the default nested editable's border  (blue) to help users navigate and understand the current position in big tables (since the toolbar is attached to the table, not to the cell).

<img width="1058" alt="screen shot 2018-06-12 at 10 29 54" src="https://user-images.githubusercontent.com/1099479/41279001-966bf5ca-6e2b-11e8-9e6f-61990356bbcf.png">

<img width="1069" alt="screen shot 2018-06-12 at 10 28 53" src="https://user-images.githubusercontent.com/1099479/41278960-81cb8068-6e2b-11e8-9605-3f02c33c3b13.png">



