### PR TITLE
Fix: The SetHeaderRowCommand should only analyze rows that are in hea…

### DIFF
--- a/src/commands/setheaderrowcommand.js
+++ b/src/commands/setheaderrowcommand.js
@@ -111,8 +111,10 @@ function getOverlappingCells( table, headingRowsToSet, currentHeadingRows ) {
 	const cellsToSplit = [];
 
 	const startAnalysisRow = headingRowsToSet > currentHeadingRows ? currentHeadingRows : 0;
+	// We're analyzing only when headingRowsToSet > 0.
+	const endAnalysisRow = headingRowsToSet - 1;
 
-	const tableWalker = new TableWalker( table, { startRow: startAnalysisRow, endRow: headingRowsToSet } );
+	const tableWalker = new TableWalker( table, { startRow: startAnalysisRow, endRow: endAnalysisRow } );
 
 	for ( const { row, rowspan, cell } of tableWalker ) {
 		if ( rowspan > 1 && row + rowspan > headingRowsToSet ) {

--- a/tests/commands/setheaderrowcommand.js
+++ b/tests/commands/setheaderrowcommand.js
@@ -252,5 +252,21 @@ describe( 'HeaderRowCommand', () => {
 				[ '10', '' ]
 			], { headingRows: 1 } ) );
 		} );
+
+		it( 'should work properly in the first row of a table', () => {
+			setData( model, modelTable( [
+				[ '00', '[]01', '02' ],
+				[ { colspan: 2, rowspan: 2, contents: '10' }, '12' ],
+				[ '22' ]
+			] ) );
+
+			command.execute();
+
+			expect( formatTable( getData( model ) ) ).to.equal( formattedModelTable( [
+				[ '00', '[]01', '02' ],
+				[ { colspan: 2, rowspan: 2, contents: '10' }, '12' ],
+				[ '22' ]
+			], { headingRows: 1 } ) );
+		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: The `SetHeaderRowCommand` should only analyze rows that are in heading section after expanding header. Closes #35.

---

### Additional information

* Another bug introduced by wrong analysis scope - one row too much was analyzed when command was checking for cells that might expand beyond a heading.
