### PR TITLE
t/50: Selected table's outline should be visible when the table is not being hovered

### DIFF
--- a/theme/table.css
+++ b/theme/table.css
@@ -11,11 +11,9 @@
 	border-collapse: collapse;
 	border-spacing: 0;
 
-	/* The outer border of the table should be slightly darker than the inner lines. */
-	&:not(:hover) {
-		outline: 1px solid hsl(0, 0%, 70%);
-		outline-offset: -1px;
-	}
+	/* The outer border of the table should be slightly darker than the inner lines.
+	Also see https://github.com/ckeditor/ckeditor5-table/issues/50. */
+	border: 1px double hsl(0, 0%, 70%);
 
 	& td,
 	& th {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Selected table's outline should be visible when the table is not being hovered. Closes #50.

---

For the reviewer: worth checking in multiple browsers.