### PR TITLE
Fix: Remove empty row in MergeCellCommand.

### DIFF
--- a/src/commands/mergecellcommand.js
+++ b/src/commands/mergecellcommand.js
@@ -93,38 +93,24 @@ export default class MergeCellCommand extends Command {
 			const cellToExpand = isMergeNext ? tableCell : cellToMerge;
 			const cellToRemove = isMergeNext ? cellToMerge : tableCell;
 
+			// Cache the parent of cell to remove for later check.
+			const removedTableCellRow = cellToRemove.parent;
+
+			// Remove table cell and merge it contents with merged cell.
 			writer.move( Range.createIn( cellToRemove ), Position.createAt( cellToExpand, 'end' ) );
-
-			let rowToCheck;
-
-			if ( !this.isHorizontal ) {
-				rowToCheck = checkEmptyRows( cellToRemove );
-			}
-
 			writer.remove( cellToRemove );
 
 			const spanAttribute = this.isHorizontal ? 'colspan' : 'rowspan';
 			const cellSpan = parseInt( tableCell.getAttribute( spanAttribute ) || 1 );
 			const cellToMergeSpan = parseInt( cellToMerge.getAttribute( spanAttribute ) || 1 );
 
+			// Update table cell span attribute and merge set selection on merged contents.
 			writer.setAttribute( spanAttribute, cellSpan + cellToMergeSpan, cellToExpand );
-
 			writer.setSelection( Range.createIn( cellToExpand ) );
 
-			if ( rowToCheck ) {
-				const table = rowToCheck.parent;
-
-				const removedRowIndex = table.getChildIndex( rowToCheck );
-
-				for ( const { cell, row, rowspan } of new TableWalker( table, { endRow: removedRowIndex } ) ) {
-					const overlapsRemovedRow = row + rowspan - 1 >= removedRowIndex;
-
-					if ( overlapsRemovedRow ) {
-						updateNumericAttribute( 'rowspan', rowspan - 1, cell, writer );
-					}
-				}
-
-				writer.remove( rowToCheck );
+			// Remove empty row after merging.
+			if ( !removedTableCellRow.childCount ) {
+				removeEmptyRow( removedTableCellRow, writer );
 			}
 		} );
 	}
@@ -220,10 +206,22 @@ function getVerticalCell( tableCell, direction ) {
 	return cellToMergeData && cellToMergeData.cell;
 }
 
-function checkEmptyRows( tableCell ) {
-	const tableRow = tableCell.parent;
+// Properly removes empty row from a table. Will update `rowspan` attribute of cells that overlaps removed row.
+//
+// @param {module:engine/model/element~Element} removedTableCellRow
+// @param {module:engine/model/writer~Writer} writer
+function removeEmptyRow( removedTableCellRow, writer ) {
+	const table = removedTableCellRow.parent;
 
-	if ( tableRow.childCount == 1 ) {
-		return tableRow;
+	const removedRowIndex = table.getChildIndex( removedTableCellRow );
+
+	for ( const { cell, row, rowspan } of new TableWalker( table, { endRow: removedRowIndex } ) ) {
+		const overlapsRemovedRow = row + rowspan - 1 >= removedRowIndex;
+
+		if ( overlapsRemovedRow ) {
+			updateNumericAttribute( 'rowspan', rowspan - 1, cell, writer );
+		}
 	}
+
+	writer.remove( removedTableCellRow );
 }

--- a/tests/commands/mergecellcommand.js
+++ b/tests/commands/mergecellcommand.js
@@ -409,6 +409,25 @@ describe( 'MergeCellCommand', () => {
 					[ '20', '21' ]
 				] ) );
 			} );
+
+			it( 'should not reduce rowspan on cells above removed empty row when merging table cells ', () => {
+				setData( model, modelTable( [
+					[ { rowspan: 2, contents: '00' }, '01', '02' ],
+					[ '11', '12' ],
+					[ { rowspan: 2, contents: '20' }, '21[]', { rowspan: 3, contents: '22' } ],
+					[ '31' ],
+					[ '40', '41' ]
+				] ) );
+
+				command.execute();
+
+				expect( formatTable( getData( model ) ) ).to.equal( formattedModelTable( [
+					[ { rowspan: 2, contents: '00' }, '01', '02' ],
+					[ '11', '12' ],
+					[ '20', '[2131]', { rowspan: 2, contents: '22' } ],
+					[ '40', '41' ]
+				] ) );
+			} );
 		} );
 	} );
 
@@ -555,6 +574,40 @@ describe( 'MergeCellCommand', () => {
 					[ { rowspan: 2, contents: '21' }, '22', { rowspan: 3, contents: '[2333]' } ],
 					[ '32' ],
 					[ { colspan: 2, contents: '40' }, '42' ]
+				] ) );
+			} );
+
+			it( 'should remove empty row if merging table cells ', () => {
+				setData( model, modelTable( [
+					[ { rowspan: 2, contents: '00' }, '01', { rowspan: 3, contents: '02' } ],
+					[ '11[]' ],
+					[ '20', '21' ]
+				] ) );
+
+				command.execute();
+
+				expect( formatTable( getData( model ) ) ).to.equal( formattedModelTable( [
+					[ '00', '[0111]', { rowspan: 2, contents: '02' } ],
+					[ '20', '21' ]
+				] ) );
+			} );
+
+			it( 'should not reduce rowspan on cells above removed empty row when merging table cells ', () => {
+				setData( model, modelTable( [
+					[ { rowspan: 2, contents: '00' }, '01', '02' ],
+					[ '11', '12' ],
+					[ { rowspan: 2, contents: '20' }, '21', { rowspan: 3, contents: '22' } ],
+					[ '31[]' ],
+					[ '40', '41' ]
+				] ) );
+
+				command.execute();
+
+				expect( formatTable( getData( model ) ) ).to.equal( formattedModelTable( [
+					[ { rowspan: 2, contents: '00' }, '01', '02' ],
+					[ '11', '12' ],
+					[ '20', '[2131]', { rowspan: 2, contents: '22' } ],
+					[ '40', '41' ]
 				] ) );
 			} );
 		} );

--- a/tests/commands/mergecellcommand.js
+++ b/tests/commands/mergecellcommand.js
@@ -380,7 +380,7 @@ describe( 'MergeCellCommand', () => {
 			} );
 		} );
 
-		describe.only( 'execute()', () => {
+		describe( 'execute()', () => {
 			it( 'should merge table cells ', () => {
 				setData( model, modelTable( [
 					[ '00', '01[]' ],

--- a/tests/commands/mergecellcommand.js
+++ b/tests/commands/mergecellcommand.js
@@ -380,7 +380,7 @@ describe( 'MergeCellCommand', () => {
 			} );
 		} );
 
-		describe( 'execute()', () => {
+		describe.only( 'execute()', () => {
 			it( 'should merge table cells ', () => {
 				setData( model, modelTable( [
 					[ '00', '01[]' ],
@@ -392,6 +392,21 @@ describe( 'MergeCellCommand', () => {
 				expect( formatTable( getData( model ) ) ).to.equal( formattedModelTable( [
 					[ '00', { rowspan: 2, contents: '[0111]' } ],
 					[ '10' ]
+				] ) );
+			} );
+
+			it( 'should remove empty row if merging table cells ', () => {
+				setData( model, modelTable( [
+					[ { rowspan: 2, contents: '00' }, '01[]', { rowspan: 3, contents: '02' } ],
+					[ '11' ],
+					[ '20', '21' ]
+				] ) );
+
+				command.execute();
+
+				expect( formatTable( getData( model ) ) ).to.equal( formattedModelTable( [
+					[ '00', '[0111]', { rowspan: 2, contents: '02' } ],
+					[ '20', '21' ]
 				] ) );
 			} );
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: The `MergeCellCommand` should check if merging cells results in empty row. Closes #16.

---

### Additional information

* The fix is simple but might not go necessarily into upcoming release.
* Also the #47 is a separate issue so this one looks fixed.
