### PR TITLE
Fix: Selection should be in the first cell of an inserted table.

### DIFF
--- a/src/commands/inserttablecommand.js
+++ b/src/commands/inserttablecommand.js
@@ -53,7 +53,11 @@ export default class InsertTableCommand extends Command {
 		const isRoot = firstPosition.parent === firstPosition.root;
 		const insertPosition = isRoot ? Position.createAt( firstPosition ) : Position.createAfter( firstPosition.parent );
 
-		tableUtils.createTable( insertPosition, rows, columns );
+		model.change( writer => {
+			const table = tableUtils.createTable( insertPosition, rows, columns );
+
+			writer.setSelection( Position.createAt( table.getChild( 0 ).getChild( 0 ) ) );
+		} );
 	}
 }
 

--- a/src/tableutils.js
+++ b/src/tableutils.js
@@ -74,17 +74,22 @@ export default class TableUtils extends Plugin {
 	 * @param {module:engine/model/position~Position} position Position at which insert a table.
 	 * @param {Number} rows Number of rows to create.
 	 * @param {Number} columns Number of columns to create.
+	 * @returns {module:engine/model/element~Element} Created table element.
 	 */
 	createTable( position, rows, columns ) {
 		const model = this.editor.model;
 
+		let table;
+
 		model.change( writer => {
-			const table = writer.createElement( 'table' );
+			table = writer.createElement( 'table' );
 
 			writer.insert( table, position );
 
 			createEmptyRows( writer, table, 0, rows, columns );
 		} );
+
+		return table;
 	}
 
 	/**

--- a/src/tableutils.js
+++ b/src/tableutils.js
@@ -79,17 +79,15 @@ export default class TableUtils extends Plugin {
 	createTable( position, rows, columns ) {
 		const model = this.editor.model;
 
-		let table;
-
-		model.change( writer => {
-			table = writer.createElement( 'table' );
+		return model.change( writer => {
+			const table = writer.createElement( 'table' );
 
 			writer.insert( table, position );
 
 			createEmptyRows( writer, table, 0, rows, columns );
-		} );
 
-		return table;
+			return table;
+		} );
 	}
 
 	/**

--- a/tests/commands/inserttablecommand.js
+++ b/tests/commands/inserttablecommand.js
@@ -96,6 +96,18 @@ describe( 'InsertTableCommand', () => {
 	} );
 
 	describe( 'execute()', () => {
+		it( 'should create a single batch', () => {
+			setData( model, '<p>foo[]</p>' );
+
+			const spy = sinon.spy();
+
+			model.document.on( 'change', spy );
+
+			command.execute( { rows: 3, columns: 4 } );
+
+			sinon.assert.calledOnce( spy );
+		} );
+
 		describe( 'collapsed selection', () => {
 			it( 'should insert table in empty root', () => {
 				setData( model, '[]' );

--- a/tests/commands/inserttablecommand.js
+++ b/tests/commands/inserttablecommand.js
@@ -19,6 +19,8 @@ import {
 import upcastTable from '../../src/converters/upcasttable';
 import TableUtils from '../../src/tableutils';
 
+import { formatTable, formattedModelTable } from '../_utils/utils';
+
 describe( 'InsertTableCommand', () => {
 	let editor, model, command;
 
@@ -100,12 +102,10 @@ describe( 'InsertTableCommand', () => {
 
 				command.execute();
 
-				expect( getData( model ) ).to.equal(
-					'<table>' +
-					'<tableRow><tableCell></tableCell><tableCell></tableCell></tableRow>' +
-					'<tableRow><tableCell></tableCell><tableCell></tableCell></tableRow>' +
-					'</table>[]'
-				);
+				expect( formatTable( getData( model ) ) ).to.equal( formattedModelTable( [
+					[ '[]', '' ],
+					[ '', '' ]
+				] ) );
 			} );
 
 			it( 'should insert table with two rows and two columns after non-empty paragraph', () => {
@@ -113,11 +113,12 @@ describe( 'InsertTableCommand', () => {
 
 				command.execute();
 
-				expect( getData( model ) ).to.equal( '<p>foo[]</p>' +
-					'<table>' +
-					'<tableRow><tableCell></tableCell><tableCell></tableCell></tableRow>' +
-					'<tableRow><tableCell></tableCell><tableCell></tableCell></tableRow>' +
-					'</table>'
+				expect( formatTable( getData( model ) ) ).to.equal(
+					'<p>foo</p>' +
+					formattedModelTable( [
+						[ '[]', '' ],
+						[ '', '' ]
+					] )
 				);
 			} );
 
@@ -126,12 +127,13 @@ describe( 'InsertTableCommand', () => {
 
 				command.execute( { rows: 3, columns: 4 } );
 
-				expect( getData( model ) ).to.equal( '<p>foo[]</p>' +
-					'<table>' +
-					'<tableRow><tableCell></tableCell><tableCell></tableCell><tableCell></tableCell><tableCell></tableCell></tableRow>' +
-					'<tableRow><tableCell></tableCell><tableCell></tableCell><tableCell></tableCell><tableCell></tableCell></tableRow>' +
-					'<tableRow><tableCell></tableCell><tableCell></tableCell><tableCell></tableCell><tableCell></tableCell></tableRow>' +
-					'</table>'
+				expect( formatTable( getData( model ) ) ).to.equal(
+					'<p>foo</p>' +
+					formattedModelTable( [
+						[ '[]', '', '', '' ],
+						[ '', '', '', '' ],
+						[ '', '', '', '' ]
+					] )
 				);
 			} );
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Selection should be in the first cell of an inserted table. Closes #61.

---

### Additional information

* Simple fix - I've made `TableUtils#createTable()` return inserted table element so `InsertTableCommand` can set the selection. I don't think that `TableUtils#createTable()` method should set the selection.
