### PR TITLE
Fix: Workaround for table widget editing bug in Edge.

### DIFF
--- a/src/converters/downcast.js
+++ b/src/converters/downcast.js
@@ -43,7 +43,7 @@ export function downcastInsertTable( options = {} ) {
 		let tableWidget;
 
 		if ( asWidget ) {
-			tableWidget = toTableWidget( figureElement, conversionApi.writer );
+			tableWidget = toTableWidget( figureElement, tableElement, conversionApi.writer );
 		}
 
 		const tableWalker = new TableWalker( table );

--- a/src/utils.js
+++ b/src/utils.js
@@ -18,8 +18,8 @@ const tableSymbol = Symbol( 'isTable' );
  * * Calls the {@link module:widget/utils~toWidget} function with the proper element's label creator.
  *
  * @param {module:engine/view/element~Element} viewFigureElement
+ * @param {module:engine/view/element~Element} viewTableElement
  * @param {module:engine/view/writer~Writer} writer An instance of the view writer.
- * @param {String} label The element's label. It will be concatenated with the table `alt` attribute if one is present.
  * @returns {module:engine/view/element~Element}
  */
 export function toTableWidget( viewFigureElement, viewTableElement, writer ) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -25,15 +25,15 @@ const tableSymbol = Symbol( 'isTable' );
 export function toTableWidget( viewFigureElement, viewTableElement, writer ) {
 	writer.setCustomProperty( tableSymbol, true, viewFigureElement );
 
-	const figureWidet = toWidget( viewFigureElement, writer, { hasSelectionHandler: true } );
+	const figureWidget = toWidget( viewFigureElement, writer, { hasSelectionHandler: true } );
 
 	// Due to a bug in Edge the `contenteditable=false` must be set on `<table>` element...
 	writer.setAttribute( 'contenteditable', 'false', viewTableElement );
 	// ...and the `<figure>` must have it set to `true` instead of removing `contenteditable` attribute.
 	// https://github.com/ckeditor/ckeditor5/issues/1067
-	writer.setAttribute( 'contenteditable', 'true', figureWidet );
+	writer.setAttribute( 'contenteditable', 'true', figureWidget );
 
-	return figureWidet;
+	return figureWidget;
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -17,15 +17,23 @@ const tableSymbol = Symbol( 'isTable' );
  * * Adds a {@link module:engine/view/element~Element#_setCustomProperty custom property} allowing to recognize the table widget element.
  * * Calls the {@link module:widget/utils~toWidget} function with the proper element's label creator.
  *
- * @param {module:engine/view/element~Element} viewElement
+ * @param {module:engine/view/element~Element} viewFigureElement
  * @param {module:engine/view/writer~Writer} writer An instance of the view writer.
  * @param {String} label The element's label. It will be concatenated with the table `alt` attribute if one is present.
  * @returns {module:engine/view/element~Element}
  */
-export function toTableWidget( viewElement, writer ) {
-	writer.setCustomProperty( tableSymbol, true, viewElement );
+export function toTableWidget( viewFigureElement, viewTableElement, writer ) {
+	writer.setCustomProperty( tableSymbol, true, viewFigureElement );
 
-	return toWidget( viewElement, writer, { hasSelectionHandler: true } );
+	const figureWidet = toWidget( viewFigureElement, writer, { hasSelectionHandler: true } );
+
+	// Due to a bug in Edge the `contenteditable=false` must be set on `<table>` element...
+	writer.setAttribute( 'contenteditable', 'false', viewTableElement );
+	// ...and the `<figure>` must have it set to `true` instead of removing `contenteditable` attribute.
+	// https://github.com/ckeditor/ckeditor5/issues/1067
+	writer.setAttribute( 'contenteditable', 'true', figureWidet );
+
+	return figureWidet;
 }
 
 /**

--- a/tests/converters/downcast.js
+++ b/tests/converters/downcast.js
@@ -274,9 +274,9 @@ describe( 'downcast converters', () => {
 				setModelData( model, modelTable( [ [ '' ] ] ) );
 
 				expect( formatTable( getViewData( viewDocument, { withoutSelection: true } ) ) ).to.equal( formatTable(
-					'<figure class="ck-widget ck-widget_selectable table" contenteditable="false">' +
+					'<figure class="ck-widget ck-widget_selectable table" contenteditable="true">' +
 					'<div class="ck ck-widget__selection-handler"></div>' +
-						'<table>' +
+						'<table contenteditable="false">' +
 							'<tbody>' +
 								'<tr><td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true"></td></tr>' +
 							'</tbody>' +
@@ -526,9 +526,9 @@ describe( 'downcast converters', () => {
 				} );
 
 				expect( formatTable( getViewData( viewDocument, { withoutSelection: true } ) ) ).to.equal( formatTable(
-					'<figure class="ck-widget ck-widget_selectable table" contenteditable="false">' +
+					'<figure class="ck-widget ck-widget_selectable table" contenteditable="true">' +
 						'<div class="ck ck-widget__selection-handler"></div>' +
-						'<table>' +
+						'<table contenteditable="false">' +
 							'<tbody>' +
 								'<tr><td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true">00</td></tr>' +
 								'<tr><td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true"></td></tr>' +
@@ -688,9 +688,9 @@ describe( 'downcast converters', () => {
 				} );
 
 				expect( formatTable( getViewData( viewDocument, { withoutSelection: true } ) ) ).to.equal( formatTable(
-					'<figure class="ck-widget ck-widget_selectable table" contenteditable="false">' +
+					'<figure class="ck-widget ck-widget_selectable table" contenteditable="true">' +
 					'<div class="ck ck-widget__selection-handler"></div>' +
-						'<table>' +
+						'<table contenteditable="false">' +
 							'<tbody>' +
 								'<tr>' +
 									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true">00</td>' +
@@ -888,9 +888,9 @@ describe( 'downcast converters', () => {
 				} );
 
 				expect( formatTable( getViewData( viewDocument, { withoutSelection: true } ) ) ).to.equal( formatTable(
-					'<figure class="ck-widget ck-widget_selectable table" contenteditable="false">' +
+					'<figure class="ck-widget ck-widget_selectable table" contenteditable="true">' +
 					'<div class="ck ck-widget__selection-handler"></div>' +
-						'<table>' +
+						'<table contenteditable="false">' +
 							'<thead>' +
 								'<tr><th class="ck-editor__editable ck-editor__nested-editable" contenteditable="true">00</th></tr>' +
 							'</thead>' +
@@ -1096,9 +1096,9 @@ describe( 'downcast converters', () => {
 				} );
 
 				expect( formatTable( getViewData( viewDocument, { withoutSelection: true } ) ) ).to.equal( formatTable(
-					'<figure class="ck-widget ck-widget_selectable table" contenteditable="false">' +
+					'<figure class="ck-widget ck-widget_selectable table" contenteditable="true">' +
 					'<div class="ck ck-widget__selection-handler"></div>' +
-						'<table>' +
+						'<table contenteditable="false">' +
 							'<tbody>' +
 								'<tr><th class="ck-editor__editable ck-editor__nested-editable" contenteditable="true">00</th></tr>' +
 							'</tbody>' +


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Workaround for a table in figure widget editing bug in Edge. See ckeditor/ckeditor5#1067.

---

### Additional information

* The issue is still open as this is a [Edge browser conteneditable=false for table in a figure element bug](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/17965212/) not CKEditor's one.
* The fix WFM but it would be nice if @Mgsy would also confirm this one works :)