### PR TITLE
Fix: Merging down rowspanned cell from the head with a cell in body i…

### DIFF
--- a/src/commands/mergecellcommand.js
+++ b/src/commands/mergecellcommand.js
@@ -199,10 +199,14 @@ function getVerticalCell( tableCell, direction ) {
 		return;
 	}
 
+	const rowspan = parseInt( tableCell.getAttribute( 'rowspan' ) || 1 );
 	const headingRows = table.getAttribute( 'headingRows' ) || 0;
 
+	const isMergeWithBodyCell = direction == 'down' && ( rowIndex + rowspan ) === headingRows;
+	const isMergeWithHeadCell = direction == 'up' && rowIndex === headingRows;
+
 	// Don't search for mergeable cell if direction points out of the current table section.
-	if ( headingRows && ( ( direction == 'down' && rowIndex === headingRows - 1 ) || ( direction == 'up' && rowIndex === headingRows ) ) ) {
+	if ( headingRows && ( isMergeWithBodyCell || isMergeWithHeadCell ) ) {
 		return;
 	}
 

--- a/tests/commands/mergecellcommand.js
+++ b/tests/commands/mergecellcommand.js
@@ -413,6 +413,16 @@ describe( 'MergeCellCommand', () => {
 				expect( command.value ).to.be.undefined;
 			} );
 
+			it( 'should be undefined if mergable cell is in other table section', () => {
+				setData( model, modelTable( [
+					[ { rowspan: 2, contents: '00[]' }, '02' ],
+					[ '12' ],
+					[ '21', '22' ]
+				], { headingRows: 2 } ) );
+
+				expect( command.value ).to.be.undefined;
+			} );
+
 			it( 'should be undefined if not in a cell', () => {
 				setData( model, '<p>11[]</p>' );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Merging down rowspanned cell from the head with a cell in body is now disabled. Closes #86.

---

### Additional information
