### PR TITLE
Fix: Downcast converter for table attributes should work with not con…

### DIFF
--- a/src/converters/downcast.js
+++ b/src/converters/downcast.js
@@ -307,7 +307,9 @@ export function downcastRemoveRow() {
 	}, { priority: 'higher' } );
 }
 
-// Renames a table cell in the view to a given element name.
+// Renames an existing table cell in the view to a given element name.
+//
+// **Note** This method will not do anything if a view table cell was not yet converted.
 //
 // @param {module:engine/model/element~Element} tableCell
 // @param {String} desiredCellElementName
@@ -315,6 +317,11 @@ export function downcastRemoveRow() {
 // @param {Boolean} asWidget
 function renameViewTableCell( tableCell, desiredCellElementName, conversionApi, asWidget ) {
 	const viewCell = conversionApi.mapper.toViewElement( tableCell );
+
+	// View cell might be not yet converted - skip it as it will be properly created by cell converter later on.
+	if ( !viewCell ) {
+		return;
+	}
 
 	let renamedCell;
 
@@ -486,6 +493,8 @@ function removeTableSectionIfEmpty( sectionName, tableElement, conversionApi ) {
 
 // Moves view table rows associated with passed model rows to the provided table section element.
 //
+// **Note** This method will skip not converted table rows.
+//
 // @param {Array.<module:engine/model/element~Element>} rowsToMove
 // @param {module:engine/view/element~Element} viewTableSection
 // @param {Object} conversionApi
@@ -494,7 +503,10 @@ function moveViewRowsToTableSection( rowsToMove, viewTableSection, conversionApi
 	for ( const tableRow of rowsToMove ) {
 		const viewTableRow = conversionApi.mapper.toViewElement( tableRow );
 
-		conversionApi.writer.move( ViewRange.createOn( viewTableRow ), ViewPosition.createAt( viewTableSection, offset ) );
+		// View table row might be not yet converted - skip it as it will be properly created by cell converter later on.
+		if ( viewTableRow ) {
+			conversionApi.writer.move( ViewRange.createOn( viewTableRow ), ViewPosition.createAt( viewTableSection, offset ) );
+		}
 	}
 }
 

--- a/tests/converters/downcast.js
+++ b/tests/converters/downcast.js
@@ -1053,6 +1053,33 @@ describe( 'downcast converters', () => {
 			], { headingRows: 2 } ) );
 		} );
 
+		it( 'should work with adding a table row and expanding heading', () => {
+			setModelData( model, modelTable( [
+				[ '00', '01' ],
+				[ '10', '11' ],
+				[ '20', '21' ]
+			], { headingRows: 1 } ) );
+
+			const table = root.getChild( 0 );
+
+			model.change( writer => {
+				writer.setAttribute( 'headingRows', 2, table );
+
+				const tableRow = writer.createElement( 'tableRow' );
+
+				writer.insert( tableRow, table, 1 );
+				writer.insertElement( 'tableCell', tableRow, 'end' );
+				writer.insertElement( 'tableCell', tableRow, 'end' );
+			} );
+
+			expect( formatTable( getViewData( viewDocument, { withoutSelection: true } ) ) ).to.equal( formattedViewTable( [
+				[ '00', '01' ],
+				[ '', '' ],
+				[ '10', '11' ],
+				[ '20', '21' ]
+			], { headingRows: 2 } ) );
+		} );
+
 		describe( 'asWidget', () => {
 			beforeEach( () => {
 				return VirtualTestEditor.create()


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Downcast converter for table attributes should work with not converted child elements. Closes #92.

---

### Additional information
