### PR TITLE
Upcast conversion fix.

### DIFF
--- a/src/converters/upcasttable.js
+++ b/src/converters/upcasttable.js
@@ -115,13 +115,12 @@ export function upcastTableCell( elementName ) {
 			conversionApi.writer.insert( tableCell, splitResult.position );
 			conversionApi.consumable.consume( viewTableCell, { name: true } );
 
-			for ( const child of viewTableCell.getChildren() ) {
-				const { modelCursor } = conversionApi.convertItem( child, ModelPosition.createAt( tableCell, 'end' ) );
+			const modelCursor = ModelPosition.createAt( tableCell );
+			conversionApi.convertChildren( viewTableCell, modelCursor );
 
-				// Ensure empty paragraph in table cell.
-				if ( modelCursor.parent.name == 'tableCell' && !modelCursor.parent.childCount ) {
-					conversionApi.writer.insertElement( 'paragraph', modelCursor );
-				}
+			// Ensure a paragraph in the model for empty table cells.
+			if ( !tableCell.childCount ) {
+				conversionApi.writer.insertElement( 'paragraph', modelCursor );
 			}
 
 			// Set conversion result range.

--- a/tests/converters/upcasttable.js
+++ b/tests/converters/upcasttable.js
@@ -418,6 +418,25 @@ describe( 'upcastTable()', () => {
 			] ) );
 		} );
 
+		it( 'should upcast table inline content to single <paragraph>', () => {
+			editor.model.schema.extend( '$text', { allowAttributes: 'bold' } );
+			editor.conversion.attributeToElement( { model: 'bold', view: 'strong' } );
+
+			editor.setData(
+				'<table>' +
+					'<tbody>' +
+						'<tr>' +
+							'<td>foo <strong>bar</strong></td>' +
+						'</tr>' +
+					'</tbody>' +
+				'</table>'
+			);
+
+			expectModel( modelTable( [
+				[ 'foo <$text bold="true">bar</$text>' ]
+			] ) );
+		} );
+
 		it( 'should upcast table with multiple <p> in table cell', () => {
 			editor.setData(
 				'<table>' +


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: The upcast conversion now properly parses inline content in table cell into single paragraph. Closes ckeditor/ckeditor5#1246.

---

### Additional information

* The table cell contents are now properly aoutoparagraphed.
