### PR TITLE
Skip text nodes between `tr` elements during table upcast

### DIFF
--- a/src/converters/upcasttable.js
+++ b/src/converters/upcasttable.js
@@ -182,9 +182,7 @@ function scanTable( viewTable ) {
 
 			// There might be some extra empty text nodes between the `tr`s.
 			// Make sure further code operates on `tr`s only. (#145)
-			const trs = Array.from( tableChild.getChildren() ).filter( el => {
-				return el.is( 'element', 'tr' );
-			} );
+			const trs = Array.from( tableChild.getChildren() ).filter( el => el.is( 'element', 'tr' ) );
 
 			for ( const tr of trs ) {
 				// This <tr> is a child of a first <thead> element.

--- a/src/converters/upcasttable.js
+++ b/src/converters/upcasttable.js
@@ -180,7 +180,13 @@ function scanTable( viewTable ) {
 				firstTheadElement = tableChild;
 			}
 
-			for ( const tr of Array.from( tableChild.getChildren() ) ) {
+			// There might be some extra empty text nodes between the `tr`s.
+			// Make sure further code operates on `tr`s only. (#145)
+			const trs = Array.from( tableChild.getChildren() ).filter( el => {
+				return el.is( 'element', 'tr' );
+			} );
+
+			for ( const tr of trs ) {
 				// This <tr> is a child of a first <thead> element.
 				if ( tr.parent.name === 'thead' && tr.parent === firstTheadElement ) {
 					tableMeta.headingRows++;

--- a/tests/converters/upcasttable.js
+++ b/tests/converters/upcasttable.js
@@ -473,4 +473,92 @@ describe( 'upcastTable()', () => {
 			] ) );
 		} );
 	} );
+
+	describe( 'handling redundant whitespacing between table elements', () => {
+		it( 'table without thead/tbody/tfoot', () => {
+			editor.setData(
+				'<table> ' +
+					'<tr> <td>1</td></tr>' +
+				'</table>'
+			);
+
+			expectModel(
+				'<table>' +
+					'<tableRow><tableCell><paragraph>1</paragraph></tableCell></tableRow>' +
+				'</table>'
+			);
+		} );
+
+		it( 'table with thead only', () => {
+			editor.setData(
+				'<table>' +
+					'<thead>' +
+						'<tr><td>1</td></tr> ' +
+						'<tr><td>2</td></tr>' +
+						' <tr><td>3</td></tr>' +
+					'</thead>' +
+				'</table>'
+			);
+
+			expectModel(
+				'<table headingRows="3">' +
+					'<tableRow><tableCell><paragraph>1</paragraph></tableCell></tableRow>' +
+					'<tableRow><tableCell><paragraph>2</paragraph></tableCell></tableRow>' +
+					'<tableRow><tableCell><paragraph>3</paragraph></tableCell></tableRow>' +
+				'</table>'
+			);
+		} );
+
+		it( 'table with thead and tbody', () => {
+			editor.setData(
+				'<table>' +
+					'<thead>   ' +
+						'<tr><td>1</td></tr>' +
+						'<tr><td>2</td></tr>\n\n   ' +
+					'</thead>' +
+					'<tbody>' +
+						'<tr><td>3</td></tr> ' +
+						'\n\n    <tr><td>4</td></tr>' +
+						'<tr>    <td>5</td></tr> ' +
+					'</tbody>' +
+				'</table>'
+			);
+
+			expectModel(
+				'<table headingRows="2">' +
+					'<tableRow><tableCell><paragraph>1</paragraph></tableCell></tableRow>' +
+					'<tableRow><tableCell><paragraph>2</paragraph></tableCell></tableRow>' +
+					'<tableRow><tableCell><paragraph>3</paragraph></tableCell></tableRow>' +
+					'<tableRow><tableCell><paragraph>4</paragraph></tableCell></tableRow>' +
+					'<tableRow><tableCell><paragraph>5</paragraph></tableCell></tableRow>' +
+				'</table>'
+			);
+		} );
+
+		it( 'table with tbody and tfoot', () => {
+			editor.setData(
+				'<table>' +
+					'<tbody>' +
+						'     <tr><td>1</td></tr>' +
+						'<tr><td>2</td></tr>' +
+						'<tr><td>3</td></tr> ' +
+						'<tr><td>4</td></tr>\n\n\n' +
+					'</tbody>\n\n' +
+					'   <tfoot>' +
+						'<tr>  <td>5</td>\n\n\n</tr>   ' +
+					'</tfoot>' +
+				'</table>'
+			);
+
+			expectModel(
+				'<table>' +
+					'<tableRow><tableCell><paragraph>1</paragraph></tableCell></tableRow>' +
+					'<tableRow><tableCell><paragraph>2</paragraph></tableCell></tableRow>' +
+					'<tableRow><tableCell><paragraph>3</paragraph></tableCell></tableRow>' +
+					'<tableRow><tableCell><paragraph>4</paragraph></tableCell></tableRow>' +
+					'<tableRow><tableCell><paragraph>5</paragraph></tableCell></tableRow>' +
+				'</table>'
+			);
+		} );
+	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Skip text nodes between `tr` elements during table upcast. Closes #145.

---

### Additional information

See #145.
