### PR TITLE
Fix: Changed  Russian translation

### DIFF
--- a/lang/translations/ru.po
+++ b/lang/translations/ru.po
@@ -35,11 +35,11 @@ msgstr "Строка заголовков"
 
 msgctxt "Label for the insert row below button."
 msgid "Insert row below"
-msgstr "Вставить строку выше"
+msgstr "Вставить строку ниже"
 
 msgctxt "Label for the insert row above button."
 msgid "Insert row above"
-msgstr "Вставить строку ниже"
+msgstr "Вставить строку выше"
 
 msgctxt "Label for the delete table row button."
 msgid "Delete row"


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Changed Russian translation

---

### Additional information

Translators apparently mixed up the text. Correct translation for «below» is «ниже», for «above» is «выше». Not vice versa. You can check it via [Google Translate](https://translate.google.com/#view=home&op=translate&sl=en&tl=ru&text=above)