### PR TITLE
t/ckeditor5/1520: Got rid of the symbol used to recognise view elements

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -10,8 +10,6 @@
 import { isWidget, toWidget } from '@ckeditor/ckeditor5-widget/src/utils';
 import { findAncestor } from './commands/utils';
 
-const tableSymbol = Symbol( 'isTable' );
-
 /**
  * Converts a given {@link module:engine/view/element~Element} to a table widget:
  * * Adds a {@link module:engine/view/element~Element#_setCustomProperty custom property} allowing to recognize the table widget element.
@@ -23,8 +21,6 @@ const tableSymbol = Symbol( 'isTable' );
  * @returns {module:engine/view/element~Element}
  */
 export function toTableWidget( viewElement, writer ) {
-	writer.setCustomProperty( tableSymbol, true, viewElement );
-
 	return toWidget( viewElement, writer, { hasSelectionHandler: true } );
 }
 
@@ -35,7 +31,7 @@ export function toTableWidget( viewElement, writer ) {
  * @returns {Boolean}
  */
 export function isTableWidget( viewElement ) {
-	return !!viewElement.getCustomProperty( tableSymbol ) && isWidget( viewElement );
+	return isWidget( viewElement ) && viewElement.hasClass( 'table' );
 }
 
 /**


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Got rid of the symbol used to recognize view elements (see ckeditor/ckeditor5#1520).

---

### Additional information

Part of https://github.com/ckeditor/ckeditor5/pull/1521
