### PR TITLE
T/ckeditor5/1620: Fix downcast conversion in data pipeline when converting single paragraph with attributes in table cell.

### DIFF
--- a/src/converters/downcast.js
+++ b/src/converters/downcast.js
@@ -384,20 +384,19 @@ function createViewTableCellElement( tableWalkerValue, tableAttributes, insertPo
 
 	const tableCell = tableWalkerValue.cell;
 
-	const isSingleParagraph = tableCell.childCount === 1 && tableCell.getChild( 0 ).name === 'paragraph';
+	const firstChild = tableCell.getChild( 0 );
+	const isSingleParagraph = tableCell.childCount === 1 && firstChild.name === 'paragraph';
 
 	conversionApi.writer.insert( insertPosition, cellElement );
 
-	if ( isSingleParagraph ) {
+	if ( isSingleParagraph && !hasAnyAttribute( firstChild ) ) {
 		const innerParagraph = tableCell.getChild( 0 );
 		const paragraphInsertPosition = conversionApi.writer.createPositionAt( cellElement, 'end' );
 
 		conversionApi.consumable.consume( innerParagraph, 'insert' );
 
 		if ( options.asWidget ) {
-			const containerName = [ ...innerParagraph.getAttributeKeys() ].length ? 'p' : 'span';
-
-			const fakeParagraph = conversionApi.writer.createContainerElement( containerName );
+			const fakeParagraph = conversionApi.writer.createContainerElement( 'span' );
 
 			conversionApi.mapper.bindElements( innerParagraph, fakeParagraph );
 			conversionApi.writer.insert( paragraphInsertPosition, fakeParagraph );
@@ -553,4 +552,12 @@ function getViewTable( viewFigure ) {
 			return child;
 		}
 	}
+}
+
+// Checks if element has any attribute set.
+//
+// @param {module:engine/model/element~Element element
+// @returns {Boolean}
+function hasAnyAttribute( element ) {
+	return !![ ...element.getAttributeKeys() ].length;
 }

--- a/tests/converters/downcast.js
+++ b/tests/converters/downcast.js
@@ -147,6 +147,35 @@ describe( 'downcast converters', () => {
 			) );
 		} );
 
+		it( 'should create table with block content (attribute on paragraph)', () => {
+			editor.conversion.attributeToAttribute(
+				{
+					model: { key: 'alignment', values: [ 'right', 'center', 'justify' ] },
+					view: {
+						right: { key: 'style', value: { 'text-align': 'right' } },
+						center: { key: 'style', value: { 'text-align': 'center' } },
+						justify: { key: 'style', value: { 'text-align': 'justify' } }
+					}
+				}
+			);
+
+			setModelData( model, modelTable( [
+				[ '<paragraph alignment="right">00</paragraph>' ]
+			] ) );
+
+			expect( formatTable( getViewData( viewDocument, { withoutSelection: true } ) ) ).to.equal( formatTable(
+				'<figure class="table">' +
+					'<table>' +
+						'<tbody>' +
+							'<tr>' +
+								'<td><p style="text-align:right">00</p></td>' +
+							'</tr>' +
+						'</tbody>' +
+					'</table>' +
+				'</figure>'
+			) );
+		} );
+
 		it( 'should be possible to overwrite', () => {
 			editor.conversion.elementToElement( { model: 'tableRow', view: 'tr', converterPriority: 'high' } );
 			editor.conversion.elementToElement( { model: 'tableCell', view: 'td', converterPriority: 'high' } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Single paragraphs with attributes inside tableCell will be properly converted in data pipeline.. Closes ckeditor/ckeditor5#1620.

---

### Additional information

* It works but probably some refactor of those converters would be nice.
