### PR TITLE
Table rows will not be added on tab key press if the associated command is disabled

### DIFF
--- a/src/tableediting.js
+++ b/src/tableediting.js
@@ -220,7 +220,7 @@ export default class TableEditing extends Plugin {
 				editor.execute( 'insertTableRowBelow' );
 
 				// Re-evaluate `isLastRow`. If `insertTableRowBelow` execution didn't add any row (because it was disabled or it got
-				// overwritten in some way) this will still be `false`. But if the row was added it will change to `true`.
+				// overwritten in some way) this will still be `true`. But if the row was added it will change to `false`.
 				isLastRow = currentRowIndex === table.childCount - 1;
 			}
 

--- a/src/tableediting.js
+++ b/src/tableediting.js
@@ -214,25 +214,22 @@ export default class TableEditing extends Plugin {
 			}
 
 			const isLastCellInRow = currentCellIndex === tableRow.childCount - 1;
-			let isLastRow = currentRowIndex === table.childCount - 1;
+			const isLastRow = currentRowIndex === table.childCount - 1;
 
 			if ( isForward && isLastRow && isLastCellInRow ) {
 				editor.execute( 'insertTableRowBelow' );
 
-				// Re-evaluate `isLastRow`. If `insertTableRowBelow` execution didn't add any row (because it was disabled or it got
-				// overwritten in some way) this will still be `true`. But if the row was added it will change to `false`.
-				isLastRow = currentRowIndex === table.childCount - 1;
+				// Check if the command actually added a row. If `insertTableRowBelow` execution didn't add a row (because it was disabled
+				// or it got overwritten) do not change the selection.
+				if ( currentRowIndex === table.childCount - 1 ) {
+					return;
+				}
 			}
 
 			let cellToFocus;
 
 			// Move to first cell in next row.
 			if ( isForward && isLastCellInRow ) {
-				if ( isLastRow ) {
-					// It's the last cell of a table - don't do anything (stay in current position).
-					return;
-				}
-
 				const nextRow = table.getChild( currentRowIndex + 1 );
 
 				cellToFocus = nextRow.getChild( 0 );

--- a/src/tableediting.js
+++ b/src/tableediting.js
@@ -214,16 +214,25 @@ export default class TableEditing extends Plugin {
 			}
 
 			const isLastCellInRow = currentCellIndex === tableRow.childCount - 1;
-			const isLastRow = currentRowIndex === table.childCount - 1;
+			let isLastRow = currentRowIndex === table.childCount - 1;
 
 			if ( isForward && isLastRow && isLastCellInRow ) {
-				editor.plugins.get( 'TableUtils' ).insertRows( table, { at: table.childCount } );
+				editor.execute( 'insertTableRowBelow' );
+
+				// Re-evaluate `isLastRow`. If `insertTableRowBelow` execution didn't add any row (because it was disabled or it got
+				// overwritten in some way) this will still be `false`. But if the row was added it will change to `true`.
+				isLastRow = currentRowIndex === table.childCount - 1;
 			}
 
 			let cellToFocus;
 
 			// Move to first cell in next row.
 			if ( isForward && isLastCellInRow ) {
+				if ( isLastRow ) {
+					// It's the last cell of a table - don't do anything (stay in current position).
+					return;
+				}
+
 				const nextRow = table.getChild( currentRowIndex + 1 );
 
 				cellToFocus = nextRow.getChild( 0 );

--- a/tests/tableediting.js
+++ b/tests/tableediting.js
@@ -294,6 +294,22 @@ describe( 'TableEditing', () => {
 				] ) );
 			} );
 
+			it( 'should not create another row and not move the caret if insertTableRowBelow command is disabled', () => {
+				setModelData( model, modelTable( [
+					[ '11', '[12]' ]
+				] ) );
+
+				const insertTableRowBelowCommand = editor.commands.get( 'insertTableRowBelow' );
+
+				insertTableRowBelowCommand.forceDisabled( 'test' );
+
+				editor.editing.view.document.fire( 'keydown', domEvtDataStub );
+
+				expect( formatTable( getModelData( model ) ) ).to.equal( formattedModelTable( [
+					[ '11', '[12]' ],
+				] ) );
+			} );
+
 			it( 'should move to the first cell of next row if on end of a row', () => {
 				setModelData( model, modelTable( [
 					[ '11', '12[]' ],

--- a/tests/tableediting.js
+++ b/tests/tableediting.js
@@ -296,7 +296,7 @@ describe( 'TableEditing', () => {
 
 			it( 'should not create another row and not move the caret if insertTableRowBelow command is disabled', () => {
 				setModelData( model, modelTable( [
-					[ '11', '[12]' ]
+					[ '11', '12[]' ]
 				] ) );
 
 				const insertTableRowBelowCommand = editor.commands.get( 'insertTableRowBelow' );
@@ -306,7 +306,7 @@ describe( 'TableEditing', () => {
 				editor.editing.view.document.fire( 'keydown', domEvtDataStub );
 
 				expect( formatTable( getModelData( model ) ) ).to.equal( formattedModelTable( [
-					[ '11', '[12]' ],
+					[ '11', '12[]' ]
 				] ) );
 			} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Table rows will not be added on tab key press if the associated command is disabled. Closes #185.