### PR TITLE
Remove deprecated configuration option.

### DIFF
--- a/src/tabletoolbar.js
+++ b/src/tabletoolbar.js
@@ -15,7 +15,7 @@ import WidgetToolbarRepository from '@ckeditor/ckeditor5-widget/src/widgettoolba
  * The table toolbar class. It creates toolbars for the table feature and its content (for now only for a table cell content).
  *
  * Table toolbar shows up when a table widget is selected. Its components (e.g. buttons) are created based on the
- * {@link module:table/table~TableConfig#toolbar `table.tableToolbar` configuration option}.
+ * {@link module:table/table~TableConfig#tableToolbar `table.tableToolbar` configuration option}.
  *
  * Table content toolbar shows up when the selection is inside the content of a table. It creates its component based on the
  * {@link module:table/table~TableConfig#contentToolbar `table.contentToolbar` configuration option}.
@@ -63,17 +63,6 @@ export default class TableToolbar extends Plugin {
 		}
 	}
 }
-
-/**
- * Items to be placed in the table content toolbar.
- *
- * **Note:** This configuration option is deprecated! Use {@link module:table/table~TableConfig#contentToolbar} instead.
- *
- * Read more about configuring toolbar in {@link module:core/editor/editorconfig~EditorConfig#toolbar}.
- *
- * @deprecated
- * @member {Array.<String>} module:table/table~TableConfig#toolbar
- */
 
 /**
  * Items to be placed in the table content toolbar.

--- a/src/tabletoolbar.js
+++ b/src/tabletoolbar.js
@@ -20,9 +20,6 @@ import WidgetToolbarRepository from '@ckeditor/ckeditor5-widget/src/widgettoolba
  * Table content toolbar shows up when the selection is inside the content of a table. It creates its component based on the
  * {@link module:table/table~TableConfig#contentToolbar `table.contentToolbar` configuration option}.
  *
- * Note that the old {@link module:table/table~TableConfig#toolbar `table.toolbar` configuration option} is deprecated
- * and will be removed in the next major release.
- *
  * @extends module:core/plugin~Plugin
  */
 export default class TableToolbar extends Plugin {
@@ -48,21 +45,12 @@ export default class TableToolbar extends Plugin {
 		const widgetToolbarRepository = editor.plugins.get( WidgetToolbarRepository );
 
 		const tableContentToolbarItems = editor.config.get( 'table.contentToolbar' );
-		const deprecatedTableContentToolbarItems = editor.config.get( 'table.toolbar' );
 
 		const tableToolbarItems = editor.config.get( 'table.tableToolbar' );
 
-		if ( deprecatedTableContentToolbarItems ) {
-			// eslint-disable-next-line
-			console.warn(
-				'`config.table.toolbar` is deprecated and will be removed in the next major release.' +
-				' Use `config.table.contentToolbar` instead.'
-			);
-		}
-
-		if ( tableContentToolbarItems || deprecatedTableContentToolbarItems ) {
+		if ( tableContentToolbarItems ) {
 			widgetToolbarRepository.register( 'tableContent', {
-				items: tableContentToolbarItems || deprecatedTableContentToolbarItems,
+				items: tableContentToolbarItems,
 				getRelatedElement: getTableWidgetAncestor
 			} );
 		}

--- a/tests/tabletoolbar.js
+++ b/tests/tabletoolbar.js
@@ -238,59 +238,6 @@ describe( 'TableToolbar', () => {
 		} );
 	} );
 
-	describe( 'deprecated toolbar', () => {
-		let editor, editorElement;
-
-		it( 'table.toolbar should not create toolbar any longer', () => {
-			editorElement = global.document.createElement( 'div' );
-			global.document.body.appendChild( editorElement );
-
-			return ClassicTestEditor
-				.create( editorElement, {
-					plugins: [ Paragraph, Table, TableToolbar, FakeButton ],
-					table: {
-						toolbar: [ 'fake_button' ]
-					}
-				} )
-				.then( newEditor => {
-					editor = newEditor;
-
-					const widgetToolbarRepository = editor.plugins.get( WidgetToolbarRepository );
-
-					expect( widgetToolbarRepository._toolbarDefinitions.get( 'tableContent' ) ).to.be.undefined;
-				} );
-		} );
-
-		it( 'table.contentToolbar should be used if both toolbars options are provided', () => {
-			editorElement = global.document.createElement( 'div' );
-			global.document.body.appendChild( editorElement );
-
-			return ClassicTestEditor
-				.create( editorElement, {
-					plugins: [ Paragraph, Table, TableToolbar, FakeButton, FooButton ],
-					table: {
-						toolbar: [ 'fake_button' ],
-						contentToolbar: [ 'foo_button' ],
-					}
-				} )
-				.then( newEditor => {
-					editor = newEditor;
-
-					const widgetToolbarRepository = editor.plugins.get( WidgetToolbarRepository );
-					const toolbarView = widgetToolbarRepository._toolbarDefinitions.get( 'tableContent' ).view;
-
-					expect( toolbarView.items ).to.have.length( 1 );
-					expect( toolbarView.items.get( 0 ).label ).to.equal( 'foo button' );
-				} );
-		} );
-
-		afterEach( () => {
-			editorElement.remove();
-
-			return editor.destroy();
-		} );
-	} );
-
 	describe( 'tableToolbar', () => {
 		let editor, element, widgetToolbarRepository, balloon, toolbar, model;
 
@@ -466,21 +413,6 @@ class FakeButton extends Plugin {
 
 			view.set( {
 				label: 'fake button'
-			} );
-
-			return view;
-		} );
-	}
-}
-
-// Plugin that adds foo_button to editor's component factory.
-class FooButton extends Plugin {
-	init() {
-		this.editor.ui.componentFactory.add( 'foo_button', locale => {
-			const view = new ButtonView( locale );
-
-			view.set( {
-				label: 'foo button'
 			} );
 
 			return view;

--- a/tests/tabletoolbar.js
+++ b/tests/tabletoolbar.js
@@ -77,7 +77,7 @@ describe( 'TableToolbar', () => {
 		} );
 
 		describe( 'toolbar', () => {
-			it( 'should use the config.table.toolbar to create items', () => {
+			it( 'should use the config.table.contenToolbar to create items', () => {
 				expect( toolbar.items ).to.have.length( 1 );
 				expect( toolbar.items.get( 0 ).label ).to.equal( 'fake button' );
 			} );

--- a/tests/tabletoolbar.js
+++ b/tests/tabletoolbar.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* global document, window */
+/* global document */
 
 import ClassicTestEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
 import TableToolbar from '../src/tabletoolbar';
@@ -239,12 +239,11 @@ describe( 'TableToolbar', () => {
 	} );
 
 	describe( 'deprecated toolbar', () => {
-		let editor, editorElement, warnMock;
+		let editor, editorElement;
 
-		it( 'table.toolbar should work as table.contentToolbar', () => {
+		it( 'table.toolbar should not create toolbar any longer', () => {
 			editorElement = global.document.createElement( 'div' );
 			global.document.body.appendChild( editorElement );
-			warnMock = sinon.stub( window.console, 'warn' );
 
 			return ClassicTestEditor
 				.create( editorElement, {
@@ -257,23 +256,14 @@ describe( 'TableToolbar', () => {
 					editor = newEditor;
 
 					const widgetToolbarRepository = editor.plugins.get( WidgetToolbarRepository );
-					const toolbarView = widgetToolbarRepository._toolbarDefinitions.get( 'tableContent' ).view;
 
-					expect( toolbarView.items ).to.have.length( 1 );
-					expect( toolbarView.items.get( 0 ).label ).to.equal( 'fake button' );
-
-					sinon.assert.calledWith(
-						warnMock,
-						'`config.table.toolbar` is deprecated and will be removed in the next major release.' +
-						' Use `config.table.contentToolbar` instead.'
-					);
+					expect( widgetToolbarRepository._toolbarDefinitions.get( 'tableContent' ) ).to.be.undefined;
 				} );
 		} );
 
 		it( 'table.contentToolbar should be used if both toolbars options are provided', () => {
 			editorElement = global.document.createElement( 'div' );
 			global.document.body.appendChild( editorElement );
-			warnMock = sinon.stub( window.console, 'warn' );
 
 			return ClassicTestEditor
 				.create( editorElement, {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Remove deprecated 'table.toolbar' configuration option. Closes #167.

BREAKING CHANGE: `config.table.toolbar` is now removed from code. Use `config.table.contentToolbar`instead.

---

### Additional information

~I remain configuration docs entry for this option. I think there should be some trace that such option existed. However Umberto doesn't mark it properly.~ It was removed as well after review comment.
Related issue ( https://github.com/cksource/umberto/issues/799 )
