### PR TITLE
Table cell view post-fixer will not crash if an element inside a cell got attribute and was removed at the same time

### DIFF
--- a/src/converters/tablecell-post-fixer.js
+++ b/src/converters/tablecell-post-fixer.js
@@ -126,7 +126,8 @@ function getElementsToCheck( view ) {
 // - span: for single paragraph with no attributes.
 // - p   : in other cases.
 function ensureProperElementName( currentViewElement, mapper, writer ) {
-	// This situation may happen if a view element was changed and removed at the same time. In this case the view element is already unbound so the post-fixer would crash.
+	// This situation may happen if a view element was changed and removed at the same time.
+	// In this case, the view element is already unbound so the post-fixer would crash.
 	if ( !currentViewElement.root.is( 'rootElement' ) ) {
 		return false;
 	}

--- a/src/converters/tablecell-post-fixer.js
+++ b/src/converters/tablecell-post-fixer.js
@@ -126,6 +126,10 @@ function getElementsToCheck( view ) {
 // - span: for single paragraph with no attributes.
 // - p   : in other cases.
 function ensureProperElementName( currentViewElement, mapper, writer ) {
+	if ( !currentViewElement.root.is( 'rootElement' ) ) {
+		return false;
+	}
+
 	const modelParagraph = mapper.toModelElement( currentViewElement );
 	const expectedViewElementName = getExpectedElementName( modelParagraph.parent, modelParagraph );
 

--- a/src/converters/tablecell-post-fixer.js
+++ b/src/converters/tablecell-post-fixer.js
@@ -126,6 +126,7 @@ function getElementsToCheck( view ) {
 // - span: for single paragraph with no attributes.
 // - p   : in other cases.
 function ensureProperElementName( currentViewElement, mapper, writer ) {
+	// This situation may happen if a view element was changed and removed at the same time. In this case the view element is already unbound so the post-fixer would crash.
 	if ( !currentViewElement.root.is( 'rootElement' ) ) {
 		return false;
 	}

--- a/tests/converters/tablecell-post-fixer.js
+++ b/tests/converters/tablecell-post-fixer.js
@@ -14,6 +14,8 @@ import env from '@ckeditor/ckeditor5-utils/src/env';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
 
+import Delete from '@ckeditor/ckeditor5-typing/src/delete';
+
 describe( 'TableCell post-fixer', () => {
 	let editor, model, doc, root, view;
 
@@ -26,7 +28,7 @@ describe( 'TableCell post-fixer', () => {
 		// Most tests assume non-edge environment but we do not set `contenteditable=false` on Edge so stub `env.isEdge`.
 		testUtils.sinon.stub( env, 'isEdge' ).get( () => false );
 
-		return ClassicTestEditor.create( element )
+		return ClassicTestEditor.create( element, { extraPlugins: [ Delete ] } )
 			.then( newEditor => {
 				editor = newEditor;
 				model = editor.model;
@@ -275,5 +277,23 @@ describe( 'TableCell post-fixer', () => {
 
 		// Trying to map view selection to DOM range shouldn't throw after post-fixer will fix inserted <p> to <span>.
 		expect( () => view.domConverter.viewRangeToDom( viewRange ) ).to.not.throw();
+	} );
+
+	// https://github.com/ckeditor/ckeditor5-table/issues/191.
+	it( 'should not fire (and crash) for removed view elements', () => {
+		editor.setData( viewTable( [ [ '<p>foo</p>' ] ] ) );
+
+		const p = root.getNodeByPath( [ 0, 0, 0, 0 ] );
+
+		// Replace table cell contents with paragraph - as model.deleteContent() does.
+		model.change( writer => {
+			writer.setSelection( writer.createRangeIn( root ) );
+			editor.execute( 'delete' ); // For some reason it didn't crash with `writer.remove()`.
+
+			writer.setAttribute( 'foo', 'bar', p );
+		} );
+
+		// Trying to map view selection to DOM range shouldn't throw after post-fixer will fix inserted <p> to <span>.
+		expect( editor.getData() ).to.equal( '' );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fixed: Table cell view post-fixer will not crash if an element inside a cell got attribute and was removed at the same time. Closes #191.