### PR TITLE
Add `aria-label` for table toolbar

### DIFF
--- a/lang/contexts.json
+++ b/lang/contexts.json
@@ -16,5 +16,6 @@
 	"Merge cell left": "Label for the merge table cell left button.",
 	"Split cell vertically": "Label for the split table cell vertically button.",
 	"Split cell horizontally": "Label for the split table cell horizontally button.",
-	"Merge cells": "Label for the merge table cells button."
+	"Merge cells": "Label for the merge table cells button.",
+	"Table toolbar": "The label describing a table toolbar attached to a table widget used by assistive technologies."
 }

--- a/lang/contexts.json
+++ b/lang/contexts.json
@@ -17,5 +17,5 @@
 	"Split cell vertically": "Label for the split table cell vertically button.",
 	"Split cell horizontally": "Label for the split table cell horizontally button.",
 	"Merge cells": "Label for the merge table cells button.",
-	"Table toolbar": "The label describing a table toolbar attached to a table widget used by assistive technologies."
+	"Table toolbar": "The label used by assistive technologies describing a table toolbar attached to a table widget."
 }

--- a/src/tabletoolbar.js
+++ b/src/tabletoolbar.js
@@ -42,6 +42,7 @@ export default class TableToolbar extends Plugin {
 	 */
 	afterInit() {
 		const editor = this.editor;
+		const t = editor.t;
 		const widgetToolbarRepository = editor.plugins.get( WidgetToolbarRepository );
 
 		const tableContentToolbarItems = editor.config.get( 'table.contentToolbar' );
@@ -50,6 +51,7 @@ export default class TableToolbar extends Plugin {
 
 		if ( tableContentToolbarItems ) {
 			widgetToolbarRepository.register( 'tableContent', {
+				ariaLabel: t( 'Table toolbar' ),
 				items: tableContentToolbarItems,
 				getRelatedElement: getTableWidgetAncestor
 			} );
@@ -57,6 +59,7 @@ export default class TableToolbar extends Plugin {
 
 		if ( tableToolbarItems ) {
 			widgetToolbarRepository.register( 'table', {
+				ariaLabel: t( 'Table toolbar' ),
 				items: tableToolbarItems,
 				getRelatedElement: getSelectedTableWidget
 			} );

--- a/tests/tabletoolbar.js
+++ b/tests/tabletoolbar.js
@@ -94,6 +94,14 @@ describe( 'TableToolbar', () => {
 					balloonClassName: 'ck-toolbar-container'
 				} );
 			} );
+
+			it( 'should set aria-label attribute', () => {
+				toolbar.render();
+
+				expect( toolbar.element.getAttribute( 'aria-label' ) ).to.equal( 'Table toolbar' );
+
+				toolbar.destroy();
+			} );
 		} );
 
 		describe( 'integration with the editor focus', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Add `aria-label` for table toolbar.

---

### Additional information

* Requires: ckeditor/ckeditor5-widget#91