### PR TITLE
t/200 Made the InsertColumnCommand work in the opposite direction when Loca…

### DIFF
--- a/src/commands/insertcolumncommand.js
+++ b/src/commands/insertcolumncommand.js
@@ -81,7 +81,7 @@ export default class InsertColumnCommand extends Command {
 		const isOrderRight = this.order === 'right';
 		const isContentLtr = contentLanguageDirection === 'ltr';
 
-		// In RTL content, the table is (visually) mirrored horizontally. Columns "before" are
+		// In RTL content, the table is (visually) mirrored horizontally. Columns logically "before" are
 		// displayed on the right–side and vice–versa. So for the UI/UX to make sense, commands must
 		// work the other way around. It is confusing and it is easy to get it wrong.
 		//

--- a/src/commands/mergecellcommand.js
+++ b/src/commands/mergecellcommand.js
@@ -82,7 +82,7 @@ export default class MergeCellCommand extends Command {
 		const doc = model.document;
 		const tableCell = findAncestor( 'tableCell', doc.selection.getFirstPosition() );
 		const cellToMerge = this.value;
-		const direction = this.direction;
+		const direction = this._localizedDirection;
 
 		model.change( writer => {
 			const isMergeNext = direction == 'right' || direction == 'down';
@@ -127,11 +127,12 @@ export default class MergeCellCommand extends Command {
 		}
 
 		const tableUtils = this.editor.plugins.get( 'TableUtils' );
+		const direction = this._localizedDirection;
 
 		// First get the cell on proper direction.
 		const cellToMerge = this.isHorizontal ?
-			getHorizontalCell( tableCell, this.direction, tableUtils ) :
-			getVerticalCell( tableCell, this.direction );
+			getHorizontalCell( tableCell, direction, tableUtils ) :
+			getVerticalCell( tableCell, direction );
 
 		if ( !cellToMerge ) {
 			return;
@@ -146,6 +147,28 @@ export default class MergeCellCommand extends Command {
 		if ( cellToMergeSpan === span ) {
 			return cellToMerge;
 		}
+	}
+
+	/**
+	 * Returns {@link #direction} of the command considering editor {@link module:core/editor/editor~Editor#locale}.
+	 *
+	 * In RTL content, the table is (visually) mirrored horizontally. Cells logically "before" are displayed on the
+	 * right–side and vice–versa. So for the UI/UX to make sense, the command must work the other way around.
+	 *
+	 * @protected
+	 */
+	get _localizedDirection() {
+		let direction = this.direction;
+
+		if ( this.editor.locale.contentLanguageDirection == 'rtl' ) {
+			if ( direction === 'right' ) {
+				direction = 'left';
+			} else if ( direction === 'left' ) {
+				direction = 'right';
+			}
+		}
+
+		return direction;
 	}
 }
 

--- a/tests/commands/insertcolumncommand.js
+++ b/tests/commands/insertcolumncommand.js
@@ -49,7 +49,9 @@ describe( 'InsertColumnCommand', () => {
 		} );
 
 		describe( 'execute()', () => {
-			it( 'should insert column in given table to the right of the selection\'s column', () => {
+			it( 'should insert column in given table to the right of the selection\'s column (LTR content)', () => {
+				editor.locale.contentLanguageDirection = 'ltr';
+
 				setData( model, modelTable( [
 					[ '11[]', '12' ],
 					[ '21', '22' ]
@@ -60,6 +62,22 @@ describe( 'InsertColumnCommand', () => {
 				expect( formatTable( getData( model ) ) ).to.equal( formattedModelTable( [
 					[ '11[]', '', '12' ],
 					[ '21', '', '22' ]
+				] ) );
+			} );
+
+			it( 'should insert column in given table to the left of the selection\'s column (RTL content)', () => {
+				editor.locale.contentLanguageDirection = 'rtl';
+
+				setData( model, modelTable( [
+					[ '11[]', '12' ],
+					[ '21', '22' ]
+				] ) );
+
+				command.execute();
+
+				expect( formatTable( getData( model ) ) ).to.equal( formattedModelTable( [
+					[ '', '11[]', '12' ],
+					[ '', '21', '22' ]
 				] ) );
 			} );
 
@@ -173,7 +191,9 @@ describe( 'InsertColumnCommand', () => {
 		} );
 
 		describe( 'execute()', () => {
-			it( 'should insert column in given table to the left of the selection\'s column', () => {
+			it( 'should insert column in given table to the left of the selection\'s column (LTR content direction)', () => {
+				editor.locale.contentLanguageDirection = 'ltr';
+
 				setData( model, modelTable( [
 					[ '11', '12[]' ],
 					[ '21', '22' ]
@@ -184,6 +204,22 @@ describe( 'InsertColumnCommand', () => {
 				expect( formatTable( getData( model ) ) ).to.equal( formattedModelTable( [
 					[ '11', '', '12[]' ],
 					[ '21', '', '22' ]
+				] ) );
+			} );
+
+			it( 'should insert column in given table to the right of the selection\'s column (LTR content direction)', () => {
+				editor.locale.contentLanguageDirection = 'rtl';
+
+				setData( model, modelTable( [
+					[ '11', '12[]' ],
+					[ '21', '22' ]
+				] ) );
+
+				command.execute();
+
+				expect( formatTable( getData( model ) ) ).to.equal( formattedModelTable( [
+					[ '11', '12[]', '', ],
+					[ '21', '22', '' ]
 				] ) );
 			} );
 

--- a/tests/commands/mergecellcommand.js
+++ b/tests/commands/mergecellcommand.js
@@ -38,9 +38,21 @@ describe( 'MergeCellCommand', () => {
 		} );
 
 		describe( 'isEnabled', () => {
-			it( 'should be true if in cell that has sibling on the right', () => {
+			it( 'should be true if in cell that has sibling on the right (LTR content direction)', () => {
+				editor.locale.contentLanguageDirection = 'ltr';
+
 				setData( model, modelTable( [
 					[ '00[]', '01' ]
+				] ) );
+
+				expect( command.isEnabled ).to.be.true;
+			} );
+
+			it( 'should be true if in cell that has sibling on the left (RTL content direction)', () => {
+				editor.locale.contentLanguageDirection = 'rtl';
+
+				setData( model, modelTable( [
+					[ '00', '01[]' ]
 				] ) );
 
 				expect( command.isEnabled ).to.be.true;
@@ -96,12 +108,24 @@ describe( 'MergeCellCommand', () => {
 		} );
 
 		describe( 'value', () => {
-			it( 'should be set to mergeable sibling if in cell that has sibling on the right', () => {
+			it( 'should be set to mergeable sibling if in cell that has sibling on the right (LTR content direction)', () => {
+				editor.locale.contentLanguageDirection = 'ltr';
+
 				setData( model, modelTable( [
 					[ '00[]', '01' ]
 				] ) );
 
 				expect( command.value ).to.equal( root.getNodeByPath( [ 0, 0, 1 ] ) );
+			} );
+
+			it( 'should be set to mergeable sibling if in cell that has sibling on the left (RTL content direction)', () => {
+				editor.locale.contentLanguageDirection = 'rtl';
+
+				setData( model, modelTable( [
+					[ '00', '01[]' ]
+				] ) );
+
+				expect( command.value ).to.equal( root.getNodeByPath( [ 0, 0, 0 ] ) );
 			} );
 
 			it( 'should be set to mergeable sibling if in cell that has sibling on the right (selection in block content)', () => {
@@ -144,9 +168,25 @@ describe( 'MergeCellCommand', () => {
 		} );
 
 		describe( 'execute()', () => {
-			it( 'should merge table cells', () => {
+			it( 'should merge table cells (LTR content direction)', () => {
+				editor.locale.contentLanguageDirection = 'ltr';
+
 				setData( model, modelTable( [
 					[ '[]00', '01' ]
+				] ) );
+
+				command.execute();
+
+				expect( formatTable( getData( model ) ) ).to.equal( formattedModelTable( [
+					[ { colspan: 2, contents: '<paragraph>[00</paragraph><paragraph>01]</paragraph>' } ]
+				] ) );
+			} );
+
+			it( 'should merge table cells (RTL content direction)', () => {
+				editor.locale.contentLanguageDirection = 'rtl';
+
+				setData( model, modelTable( [
+					[ '00', '[]01' ]
 				] ) );
 
 				command.execute();
@@ -218,9 +258,21 @@ describe( 'MergeCellCommand', () => {
 		} );
 
 		describe( 'isEnabled', () => {
-			it( 'should be true if in cell that has sibling on the left', () => {
+			it( 'should be true if in cell that has sibling on the left (LTR content direction)', () => {
+				editor.locale.contentLanguageDirection = 'ltr';
+
 				setData( model, modelTable( [
 					[ '00', '01[]' ]
+				] ) );
+
+				expect( command.isEnabled ).to.be.true;
+			} );
+
+			it( 'should be true if in cell that has sibling on the right (RTL content direction)', () => {
+				editor.locale.contentLanguageDirection = 'rtl';
+
+				setData( model, modelTable( [
+					[ '00[]', '01' ]
 				] ) );
 
 				expect( command.isEnabled ).to.be.true;
@@ -276,12 +328,24 @@ describe( 'MergeCellCommand', () => {
 		} );
 
 		describe( 'value', () => {
-			it( 'should be set to mergeable sibling if in cell that has sibling on the left', () => {
+			it( 'should be set to mergeable sibling if in cell that has sibling on the left (LTR content direction)', () => {
+				editor.locale.contentLanguageDirection = 'ltr';
+
 				setData( model, modelTable( [
 					[ '00', '01[]' ]
 				] ) );
 
 				expect( command.value ).to.equal( root.getNodeByPath( [ 0, 0, 0 ] ) );
+			} );
+
+			it( 'should be set to mergeable sibling if in cell that has sibling on the right (RTL content direction)', () => {
+				editor.locale.contentLanguageDirection = 'rtl';
+
+				setData( model, modelTable( [
+					[ '00[]', '01' ]
+				] ) );
+
+				expect( command.value ).to.equal( root.getNodeByPath( [ 0, 0, 1 ] ) );
 			} );
 
 			it( 'should be set to mergeable sibling if in cell that has sibling on the left (selection in block content)', () => {
@@ -324,9 +388,25 @@ describe( 'MergeCellCommand', () => {
 		} );
 
 		describe( 'execute()', () => {
-			it( 'should merge table cells', () => {
+			it( 'should merge table cells (LTR content direction)', () => {
+				editor.locale.contentLanguageDirection = 'ltr';
+
 				setData( model, modelTable( [
 					[ '00', '[]01' ]
+				] ) );
+
+				command.execute();
+
+				expect( formatTable( getData( model ) ) ).to.equal( formattedModelTable( [
+					[ { colspan: 2, contents: '<paragraph>[00</paragraph><paragraph>01]</paragraph>' } ]
+				] ) );
+			} );
+
+			it( 'should merge table cells (RTL content direction)', () => {
+				editor.locale.contentLanguageDirection = 'rtl';
+
+				setData( model, modelTable( [
+					[ '00[]', '01' ]
 				] ) );
 
 				command.execute();
@@ -398,7 +478,20 @@ describe( 'MergeCellCommand', () => {
 		} );
 
 		describe( 'isEnabled', () => {
-			it( 'should be true if in cell that has mergeable cell in next row', () => {
+			it( 'should be true if in cell that has mergeable cell in next row (LTR content direction)', () => {
+				editor.locale.contentLanguageDirection = 'ltr';
+
+				setData( model, modelTable( [
+					[ '00', '01[]' ],
+					[ '10', '11' ]
+				] ) );
+
+				expect( command.isEnabled ).to.be.true;
+			} );
+
+			it( 'should be true if in cell that has mergeable cell in next row (RTL content direction)', () => {
+				editor.locale.contentLanguageDirection = 'rtl';
+
 				setData( model, modelTable( [
 					[ '00', '01[]' ],
 					[ '10', '11' ]
@@ -451,7 +544,20 @@ describe( 'MergeCellCommand', () => {
 		} );
 
 		describe( 'value', () => {
-			it( 'should be set to mergeable cell', () => {
+			it( 'should be set to mergeable cell (LTR content direction)', () => {
+				editor.locale.contentLanguageDirection = 'ltr';
+
+				setData( model, modelTable( [
+					[ '00', '01[]' ],
+					[ '10', '11' ]
+				] ) );
+
+				expect( command.value ).to.equal( root.getNodeByPath( [ 0, 1, 1 ] ) );
+			} );
+
+			it( 'should be set to mergeable cell (RTL content direction)', () => {
+				editor.locale.contentLanguageDirection = 'rtl';
+
 				setData( model, modelTable( [
 					[ '00', '01[]' ],
 					[ '10', '11' ]
@@ -515,7 +621,25 @@ describe( 'MergeCellCommand', () => {
 		} );
 
 		describe( 'execute()', () => {
-			it( 'should merge table cells', () => {
+			it( 'should merge table cells (LTR content direction)', () => {
+				editor.locale.contentLanguageDirection = 'ltr';
+
+				setData( model, modelTable( [
+					[ '00', '01[]' ],
+					[ '10', '11' ]
+				] ) );
+
+				command.execute();
+
+				expect( formatTable( getData( model ) ) ).to.equal( formattedModelTable( [
+					[ '00', { rowspan: 2, contents: '<paragraph>[01</paragraph><paragraph>11]</paragraph>' } ],
+					[ '10' ]
+				] ) );
+			} );
+
+			it( 'should merge table cells (RTL content direction)', () => {
+				editor.locale.contentLanguageDirection = 'rtl';
+
 				setData( model, modelTable( [
 					[ '00', '01[]' ],
 					[ '10', '11' ]
@@ -633,7 +757,20 @@ describe( 'MergeCellCommand', () => {
 		} );
 
 		describe( 'isEnabled', () => {
-			it( 'should be true if in cell that has mergeable cell in previous row', () => {
+			it( 'should be true if in cell that has mergeable cell in previous row (LTR content direction)', () => {
+				editor.locale.contentLanguageDirection = 'ltr';
+
+				setData( model, modelTable( [
+					[ '00', '01' ],
+					[ '10', '11[]' ]
+				] ) );
+
+				expect( command.isEnabled ).to.be.true;
+			} );
+
+			it( 'should be true if in cell that has mergeable cell in previous row (RTL content direction)', () => {
+				editor.locale.contentLanguageDirection = 'rtl';
+
 				setData( model, modelTable( [
 					[ '00', '01' ],
 					[ '10', '11[]' ]
@@ -686,7 +823,20 @@ describe( 'MergeCellCommand', () => {
 		} );
 
 		describe( 'value', () => {
-			it( 'should be set to mergeable cell', () => {
+			it( 'should be set to mergeable cell (LTR content direction)', () => {
+				editor.locale.contentLanguageDirection = 'ltr';
+
+				setData( model, modelTable( [
+					[ '00', '01' ],
+					[ '10', '11[]' ]
+				] ) );
+
+				expect( command.value ).to.equal( root.getNodeByPath( [ 0, 0, 1 ] ) );
+			} );
+
+			it( 'should be set to mergeable cell (RTL content direction)', () => {
+				editor.locale.contentLanguageDirection = 'rtl';
+
 				setData( model, modelTable( [
 					[ '00', '01' ],
 					[ '10', '11[]' ]
@@ -751,7 +901,25 @@ describe( 'MergeCellCommand', () => {
 		} );
 
 		describe( 'execute()', () => {
-			it( 'should merge table cells', () => {
+			it( 'should merge table cells (LTR content direction)', () => {
+				editor.locale.contentLanguageDirection = 'ltr';
+
+				setData( model, modelTable( [
+					[ '00', '01' ],
+					[ '10', '[]11' ]
+				] ) );
+
+				command.execute();
+
+				expect( formatTable( getData( model ) ) ).to.equal( formattedModelTable( [
+					[ '00', { rowspan: 2, contents: '<paragraph>[01</paragraph><paragraph>11]</paragraph>' } ],
+					[ '10' ]
+				] ) );
+			} );
+
+			it( 'should merge table cells (RTL content direction)', () => {
+				editor.locale.contentLanguageDirection = 'rtl';
+
 				setData( model, modelTable( [
 					[ '00', '01' ],
 					[ '10', '[]11' ]


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Made the `InsertColumnCommand` and `MergeCellCommand` work in the opposite direction when `Locale#contentLanguageDirection` is `'rtl'`. Closes #200.
