### PR TITLE
Disable horizontal merge between header and body cells.

### DIFF
--- a/src/commands/mergecellcommand.js
+++ b/src/commands/mergecellcommand.js
@@ -153,7 +153,10 @@ export default class MergeCellCommand extends Command {
 // @param {String} direction
 // @returns {module:engine/model/node~Node|null}
 function getHorizontalCell( tableCell, direction, tableUtils ) {
+	const tableRow = tableCell.parent;
+	const table = tableRow.parent;
 	const horizontalCell = direction == 'right' ? tableCell.nextSibling : tableCell.previousSibling;
+	const headingColumns = table.getAttribute( 'headingColumns' ) || 0;
 
 	if ( !horizontalCell ) {
 		return;
@@ -168,6 +171,13 @@ function getHorizontalCell( tableCell, direction, tableUtils ) {
 	const { column: rightCellColumn } = tableUtils.getCellLocation( cellOnRight );
 
 	const leftCellSpan = parseInt( cellOnLeft.getAttribute( 'colspan' ) || 1 );
+
+	const isMergeWithBodyCell = direction == 'right' && rightCellColumn === headingColumns;
+	const isMergeWithHeadCell = direction == 'left' && leftCellColumn === ( headingColumns - 1 );
+
+	if ( headingColumns && ( isMergeWithBodyCell || isMergeWithHeadCell ) ) {
+		return;
+	}
 
 	// The cell on the right must have index that is distant to the cell on the left by the left cell's width (colspan).
 	const cellsAreTouching = leftCellColumn + leftCellSpan === rightCellColumn;

--- a/tests/commands/mergecellcommand.js
+++ b/tests/commands/mergecellcommand.js
@@ -93,6 +93,14 @@ describe( 'MergeCellCommand', () => {
 
 				expect( command.isEnabled ).to.be.false;
 			} );
+
+			it( 'should be false if mergeable cell is in other table section then current cell', () => {
+				setData( model, modelTable( [
+					[ '00[]', '01' ],
+				], { headingColumns: 1 } ) );
+
+				expect( command.isEnabled ).to.be.false;
+			} );
 		} );
 
 		describe( 'value', () => {
@@ -270,6 +278,14 @@ describe( 'MergeCellCommand', () => {
 
 			it( 'should be false if not in a cell', () => {
 				setData( model, '<paragraph>11[]</paragraph>' );
+
+				expect( command.isEnabled ).to.be.false;
+			} );
+
+			it( 'should be false if mergeable cell is in other table section then current cell', () => {
+				setData( model, modelTable( [
+					[ '00', '01[]' ],
+				], { headingColumns: 1 } ) );
 
 				expect( command.isEnabled ).to.be.false;
 			} );


### PR DESCRIPTION
Fix: Disable horizontal cell merges between header and body cells. Closes ckeditor/ckeditor5#5744.

NOTE: Prevents merging between column header cells and body cells
---

### Additional information

This assumes this is the direction to take on the issue documented here: https://github.com/ckeditor/ckeditor5/issues/5744
