### PR TITLE
I/6098: Add `'px'` default unit to commands operationg on lengths.

### DIFF
--- a/src/commands/utils.js
+++ b/src/commands/utils.js
@@ -87,9 +87,9 @@ export function getSingleValue( objectOrString ) {
 }
 
 /**
- * Add a unit to a value if the value is a number or string with a number.
+ * Adds a unit to a value if the value is a number or a string representing a number.
  *
- * Does nothing to a non-numeric values.
+ * **Note**: It does nothing to non-numeric values.
  *
  *		getSingleValue( 25, 'px' );		// '25px'
  *		getSingleValue( 25, 'em' );		// '25em'

--- a/src/commands/utils.js
+++ b/src/commands/utils.js
@@ -85,3 +85,31 @@ export function getSingleValue( objectOrString ) {
 		return top;
 	}
 }
+
+/**
+ * Add a unit to a value if the value is a number or string with a number.
+ *
+ * Does nothing to a non-numeric values.
+ *
+ *		getSingleValue( 25, 'px' );		// '25px'
+ *		getSingleValue( 25, 'em' );		// '25em'
+ *		getSingleValue( '25em', 'px' );	// '25em'
+ *		getSingleValue( 'foo', 'px' );	// 'foo'
+ *
+ * @param {*} value
+ * @param {String} defaultUnit A default unit added to a numeric value.
+ * @returns {String|*}
+ */
+export function addDefaultUnitToNumericValue( value, defaultUnit ) {
+	const numericValue = parseFloat( value );
+
+	if ( Number.isNaN( numericValue ) ) {
+		return value;
+	}
+
+	if ( String( numericValue ) !== String( value ) ) {
+		return value;
+	}
+
+	return `${ numericValue }${ defaultUnit }`;
+}

--- a/src/tablecellproperties/commands/tablecellborderwidthcommand.js
+++ b/src/tablecellproperties/commands/tablecellborderwidthcommand.js
@@ -22,13 +22,13 @@ import TableCellPropertyCommand from './tablecellpropertycommand';
  *			value: '5px'
  *		} );
  *
- * **Note**: This command adds a default `'px'` unit to a numeric values. Executing:
+ * **Note**: This command adds the default `'px'` unit to numeric values. Executing:
  *
  *		editor.execute( 'tableCellBorderWidth', {
  *			value: '5'
  *		} );
  *
- * Will set `borderWidth` attribute to `'5px'` in the model.
+ * will set the `borderWidth` attribute to `'5px'` in the model.
  *
  * @extends module:core/command~Command
  */

--- a/src/tablecellproperties/commands/tablecellborderwidthcommand.js
+++ b/src/tablecellproperties/commands/tablecellborderwidthcommand.js
@@ -22,6 +22,14 @@ import TableCellPropertyCommand from './tablecellpropertycommand';
  *			value: '5px'
  *		} );
  *
+ * **Note**: This command adds a default `'px'` unit to a numeric values. Executing:
+ *
+ *		editor.execute( 'tableCellBorderWidth', {
+ *			value: '5'
+ *		} );
+ *
+ * Will set `borderWidth` attribute to `'5px'` in the model.
+ *
  * @extends module:core/command~Command
  */
 export default class TableCellBorderWidthCommand extends TableCellPropertyCommand {

--- a/src/tablecellproperties/commands/tablecellborderwidthcommand.js
+++ b/src/tablecellproperties/commands/tablecellborderwidthcommand.js
@@ -7,8 +7,8 @@
  * @module table/tablecellproperties/commands/tablecellborderwidthcommand
  */
 
+import { addDefaultUnitToNumericValue, getSingleValue } from '../../commands/utils';
 import TableCellPropertyCommand from './tablecellpropertycommand';
-import { getSingleValue } from '../../commands/utils';
 
 /**
  * The table cell border width command.
@@ -43,5 +43,12 @@ export default class TableCellBorderWidthCommand extends TableCellPropertyComman
 		}
 
 		return getSingleValue( tableCell.getAttribute( this.attributeName ) );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	_getValueToSet( value ) {
+		return addDefaultUnitToNumericValue( value, 'px' );
 	}
 }

--- a/src/tablecellproperties/commands/tablecellheightcommand.js
+++ b/src/tablecellproperties/commands/tablecellheightcommand.js
@@ -22,13 +22,13 @@ import TableCellPropertyCommand from './tablecellpropertycommand';
  *			value: '50px'
  *		} );
  *
- * **Note**: This command adds a default `'px'` unit to a numeric values. Executing:
+ * **Note**: This command adds the default `'px'` unit to numeric values. Executing:
  *
  *		editor.execute( 'tableCellHeight', {
  *			value: '50'
  *		} );
  *
- * Will set `height` attribute to `'50px'` in the model.
+ * will set the `height` attribute to `'50px'` in the model.
  *
  * @extends module:table/tablecellproperties/commands/tablecellpropertycommand
  */

--- a/src/tablecellproperties/commands/tablecellheightcommand.js
+++ b/src/tablecellproperties/commands/tablecellheightcommand.js
@@ -22,6 +22,14 @@ import TableCellPropertyCommand from './tablecellpropertycommand';
  *			value: '50px'
  *		} );
  *
+ * **Note**: This command adds a default `'px'` unit to a numeric values. Executing:
+ *
+ *		editor.execute( 'tableCellHeight', {
+ *			value: '50'
+ *		} );
+ *
+ * Will set `height` attribute to `'50px'` in the model.
+ *
  * @extends module:table/tablecellproperties/commands/tablecellpropertycommand
  */
 export default class TableCellHeightCommand extends TableCellPropertyCommand {

--- a/src/tablecellproperties/commands/tablecellheightcommand.js
+++ b/src/tablecellproperties/commands/tablecellheightcommand.js
@@ -7,6 +7,7 @@
  * @module table/tablecellproperties/commands/tablecellheightcommand
  */
 
+import { addDefaultUnitToNumericValue } from '../../commands/utils';
 import TableCellPropertyCommand from './tablecellpropertycommand';
 
 /**
@@ -31,5 +32,12 @@ export default class TableCellHeightCommand extends TableCellPropertyCommand {
 	 */
 	constructor( editor ) {
 		super( editor, 'height' );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	_getValueToSet( value ) {
+		return addDefaultUnitToNumericValue( value, 'px' );
 	}
 }

--- a/src/tablecellproperties/commands/tablecellpaddingcommand.js
+++ b/src/tablecellproperties/commands/tablecellpaddingcommand.js
@@ -22,6 +22,13 @@ import TableCellPropertyCommand from './tablecellpropertycommand';
  *			value: '5px'
  *		} );
  *
+ * **Note**: This command adds a default `'px'` unit to a numeric values. Executing:
+ *
+ *		editor.execute( 'tableCellPadding', {
+ *			value: '5'
+ *		} );
+ *
+ * Will set `padding` attribute to `'5px'` in the model.
  * @extends module:table/tablecellproperties/commands/tablecellpropertycommand
  */
 export default class TableCellPaddingCommand extends TableCellPropertyCommand {

--- a/src/tablecellproperties/commands/tablecellpaddingcommand.js
+++ b/src/tablecellproperties/commands/tablecellpaddingcommand.js
@@ -7,8 +7,8 @@
  * @module table/tablecellproperties/commands/tablecellpaddingcommand
  */
 
+import { addDefaultUnitToNumericValue, getSingleValue } from '../../commands/utils';
 import TableCellPropertyCommand from './tablecellpropertycommand';
-import { getSingleValue } from '../../commands/utils';
 
 /**
  * The table cell padding command.
@@ -43,5 +43,12 @@ export default class TableCellPaddingCommand extends TableCellPropertyCommand {
 		}
 
 		return getSingleValue( tableCell.getAttribute( this.attributeName ) );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	_getValueToSet( value ) {
+		return addDefaultUnitToNumericValue( value, 'px' );
 	}
 }

--- a/src/tablecellproperties/commands/tablecellpaddingcommand.js
+++ b/src/tablecellproperties/commands/tablecellpaddingcommand.js
@@ -22,13 +22,13 @@ import TableCellPropertyCommand from './tablecellpropertycommand';
  *			value: '5px'
  *		} );
  *
- * **Note**: This command adds a default `'px'` unit to a numeric values. Executing:
+ * **Note**: This command adds the default `'px'` unit to numeric values. Executing:
  *
  *		editor.execute( 'tableCellPadding', {
  *			value: '5'
  *		} );
  *
- * Will set `padding` attribute to `'5px'` in the model.
+ * will set the `padding` attribute to `'5px'` in the model.
  * @extends module:table/tablecellproperties/commands/tablecellpropertycommand
  */
 export default class TableCellPaddingCommand extends TableCellPropertyCommand {

--- a/src/tablecellproperties/commands/tablecellpropertycommand.js
+++ b/src/tablecellproperties/commands/tablecellpropertycommand.js
@@ -89,7 +89,7 @@ export default class TableCellPropertyCommand extends Command {
 	}
 
 	/**
-	 * Returns proper model value. Can be used to add default unit to numeric values.
+	 * Returns the proper model value. Can be used to add a default unit to numeric values.
 	 *
 	 * @private
 	 * @param {*} value

--- a/src/tablecellproperties/commands/tablecellpropertycommand.js
+++ b/src/tablecellproperties/commands/tablecellpropertycommand.js
@@ -62,10 +62,11 @@ export default class TableCellPropertyCommand extends Command {
 
 		const tableCells = Array.from( selection.getSelectedBlocks() )
 			.map( element => findAncestor( 'tableCell', model.createPositionAt( element, 0 ) ) );
+		const valueToSet = this._getValueToSet( value );
 
 		model.enqueueChange( batch || 'default', writer => {
-			if ( value ) {
-				tableCells.forEach( tableCell => writer.setAttribute( this.attributeName, value, tableCell ) );
+			if ( valueToSet ) {
+				tableCells.forEach( tableCell => writer.setAttribute( this.attributeName, valueToSet, tableCell ) );
 			} else {
 				tableCells.forEach( tableCell => writer.removeAttribute( this.attributeName, tableCell ) );
 			}
@@ -85,5 +86,16 @@ export default class TableCellPropertyCommand extends Command {
 		}
 
 		return tableCell.getAttribute( this.attributeName );
+	}
+
+	/**
+	 * Returns proper model value. Can be used to add default unit to numeric values.
+	 *
+	 * @private
+	 * @param {*} value
+	 * @returns {*}
+	 */
+	_getValueToSet( value ) {
+		return value;
 	}
 }

--- a/src/tablecellproperties/commands/tablecellwidthcommand.js
+++ b/src/tablecellproperties/commands/tablecellwidthcommand.js
@@ -22,6 +22,14 @@ import TableCellPropertyCommand from './tablecellpropertycommand';
  *			value: '50px'
  *		} );
  *
+ * **Note**: This command adds a default `'px'` unit to a numeric values. Executing:
+ *
+ *		editor.execute( 'tableCellWidth', {
+ *			value: '50'
+ *		} );
+ *
+ * Will set `width` attribute to `'50px'` in the model.
+ *
  * @extends module:table/tablecellproperties/commands/tablecellpropertycommand
  */
 export default class TableCellWidthCommand extends TableCellPropertyCommand {

--- a/src/tablecellproperties/commands/tablecellwidthcommand.js
+++ b/src/tablecellproperties/commands/tablecellwidthcommand.js
@@ -7,6 +7,7 @@
  * @module table/tablecellproperties/commands/tablecellwidthcommand
  */
 
+import { addDefaultUnitToNumericValue } from '../../commands/utils';
 import TableCellPropertyCommand from './tablecellpropertycommand';
 
 /**
@@ -31,5 +32,12 @@ export default class TableCellWidthCommand extends TableCellPropertyCommand {
 	 */
 	constructor( editor ) {
 		super( editor, 'width' );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	_getValueToSet( value ) {
+		return addDefaultUnitToNumericValue( value, 'px' );
 	}
 }

--- a/src/tableproperties/commands/tableborderwidthcommand.js
+++ b/src/tableproperties/commands/tableborderwidthcommand.js
@@ -22,13 +22,13 @@ import TablePropertyCommand from './tablepropertycommand';
  *			value: '5px'
  *		} );
  *
- * **Note**: This command adds a default `'px'` unit to a numeric values. Executing:
+ * **Note**: This command adds the default `'px'` unit to numeric values. Executing:
  *
  *		editor.execute( 'tableBorderWidth', {
  *			value: '5'
  *		} );
  *
- * Will set `borderWidth` attribute to `'5px'` in the model.
+ * Will set the `borderWidth` attribute to `'5px'` in the model.
  *
  * @extends module:table/tableproperties/commands/tablepropertycommand
  */

--- a/src/tableproperties/commands/tableborderwidthcommand.js
+++ b/src/tableproperties/commands/tableborderwidthcommand.js
@@ -22,6 +22,14 @@ import TablePropertyCommand from './tablepropertycommand';
  *			value: '5px'
  *		} );
  *
+ * **Note**: This command adds a default `'px'` unit to a numeric values. Executing:
+ *
+ *		editor.execute( 'tableBorderWidth', {
+ *			value: '5'
+ *		} );
+ *
+ * Will set `borderWidth` attribute to `'5px'` in the model.
+ *
  * @extends module:table/tableproperties/commands/tablepropertycommand
  */
 export default class TableBorderWidthCommand extends TablePropertyCommand {

--- a/src/tableproperties/commands/tableborderwidthcommand.js
+++ b/src/tableproperties/commands/tableborderwidthcommand.js
@@ -7,8 +7,8 @@
  * @module table/tableproperties/commands/tableborderwidthcommand
  */
 
+import { addDefaultUnitToNumericValue, getSingleValue } from '../../commands/utils';
 import TablePropertyCommand from './tablepropertycommand';
-import { getSingleValue } from '../../commands/utils';
 
 /**
  * The table width border command.
@@ -43,5 +43,12 @@ export default class TableBorderWidthCommand extends TablePropertyCommand {
 		}
 
 		return getSingleValue( table.getAttribute( this.attributeName ) );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	_getValueToSet( value ) {
+		return addDefaultUnitToNumericValue( value, 'px' );
 	}
 }

--- a/src/tableproperties/commands/tableheightcommand.js
+++ b/src/tableproperties/commands/tableheightcommand.js
@@ -22,6 +22,14 @@ import { addDefaultUnitToNumericValue } from '../../commands/utils';
  *			value: '500px'
  *		} );
  *
+ * **Note**: This command adds a default `'px'` unit to a numeric values. Executing:
+ *
+ *		editor.execute( 'tableHeight', {
+ *			value: '50'
+ *		} );
+ *
+ * Will set `height` attribute to `'50px'` in the model.
+ *
  * @extends module:core/command~Command
  */
 export default class TableHeightCommand extends TablePropertyCommand {

--- a/src/tableproperties/commands/tableheightcommand.js
+++ b/src/tableproperties/commands/tableheightcommand.js
@@ -8,6 +8,7 @@
  */
 
 import TablePropertyCommand from './tablepropertycommand';
+import { addDefaultUnitToNumericValue } from '../../commands/utils';
 
 /**
  * The table height command.
@@ -31,5 +32,12 @@ export default class TableHeightCommand extends TablePropertyCommand {
 	 */
 	constructor( editor ) {
 		super( editor, 'height' );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	_getValueToSet( value ) {
+		return addDefaultUnitToNumericValue( value, 'px' );
 	}
 }

--- a/src/tableproperties/commands/tableheightcommand.js
+++ b/src/tableproperties/commands/tableheightcommand.js
@@ -22,13 +22,13 @@ import { addDefaultUnitToNumericValue } from '../../commands/utils';
  *			value: '500px'
  *		} );
  *
- * **Note**: This command adds a default `'px'` unit to a numeric values. Executing:
+ * **Note**: This command adds the default `'px'` unit to numeric values. Executing:
  *
  *		editor.execute( 'tableHeight', {
  *			value: '50'
  *		} );
  *
- * Will set `height` attribute to `'50px'` in the model.
+ * Will set the `height` attribute to `'50px'` in the model.
  *
  * @extends module:core/command~Command
  */

--- a/src/tableproperties/commands/tablepropertycommand.js
+++ b/src/tableproperties/commands/tablepropertycommand.js
@@ -61,10 +61,11 @@ export default class TablePropertyCommand extends Command {
 		const { value, batch } = options;
 
 		const table = findAncestor( 'table', selection.getFirstPosition() );
+		const valueToSet = this._getValueToSet( value );
 
 		model.enqueueChange( batch || 'default', writer => {
-			if ( value ) {
-				writer.setAttribute( this.attributeName, value, table );
+			if ( valueToSet ) {
+				writer.setAttribute( this.attributeName, valueToSet, table );
 			} else {
 				writer.removeAttribute( this.attributeName, table );
 			}
@@ -84,5 +85,16 @@ export default class TablePropertyCommand extends Command {
 		}
 
 		return table.getAttribute( this.attributeName );
+	}
+
+	/**
+	 * Returns proper model value. Can be used to add default unit to numeric values.
+	 *
+	 * @private
+	 * @param {*} value
+	 * @returns {*}
+	 */
+	_getValueToSet( value ) {
+		return value;
 	}
 }

--- a/src/tableproperties/commands/tablepropertycommand.js
+++ b/src/tableproperties/commands/tablepropertycommand.js
@@ -88,7 +88,7 @@ export default class TablePropertyCommand extends Command {
 	}
 
 	/**
-	 * Returns proper model value. Can be used to add default unit to numeric values.
+	 * Returns the proper model value. Can be used to add a default unit to numeric values.
 	 *
 	 * @private
 	 * @param {*} value

--- a/src/tableproperties/commands/tablewidthcommand.js
+++ b/src/tableproperties/commands/tablewidthcommand.js
@@ -22,6 +22,14 @@ import TablePropertyCommand from './tablepropertycommand';
  *			value: '400px'
  *		} );
  *
+ * **Note**: This command adds a default `'px'` unit to a numeric values. Executing:
+ *
+ *		editor.execute( 'tableWidth', {
+ *			value: '50'
+ *		} );
+ *
+ * Will set `width` attribute to `'50px'` in the model.
+ *
  * @extends module:table/tableproperties/commands/tablepropertycommand
  */
 export default class TableWidthCommand extends TablePropertyCommand {

--- a/src/tableproperties/commands/tablewidthcommand.js
+++ b/src/tableproperties/commands/tablewidthcommand.js
@@ -22,13 +22,13 @@ import TablePropertyCommand from './tablepropertycommand';
  *			value: '400px'
  *		} );
  *
- * **Note**: This command adds a default `'px'` unit to a numeric values. Executing:
+ * **Note**: This command adds the default `'px'` unit to numeric values. Executing:
  *
  *		editor.execute( 'tableWidth', {
  *			value: '50'
  *		} );
  *
- * Will set `width` attribute to `'50px'` in the model.
+ * Will set the `width` attribute to `'50px'` in the model.
  *
  * @extends module:table/tableproperties/commands/tablepropertycommand
  */

--- a/src/tableproperties/commands/tablewidthcommand.js
+++ b/src/tableproperties/commands/tablewidthcommand.js
@@ -7,6 +7,7 @@
  * @module table/tableproperties/commands/tablewidthcommand
  */
 
+import { addDefaultUnitToNumericValue } from '../../commands/utils';
 import TablePropertyCommand from './tablepropertycommand';
 
 /**
@@ -31,5 +32,12 @@ export default class TableWidthCommand extends TablePropertyCommand {
 	 */
 	constructor( editor ) {
 		super( editor, 'width' );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	_getValueToSet( value ) {
+		return addDefaultUnitToNumericValue( value, 'px' );
 	}
 }

--- a/src/ui/utils.js
+++ b/src/ui/utils.js
@@ -153,7 +153,7 @@ export function colorFieldValidator( value ) {
 }
 
 /**
- * Returns `true` when the passed value is an empty string or a valid CSS length expression.
+ * Returns `true` when the passed value is an empty string, number without unit or a valid CSS length expression.
  * Otherwise, `false` is returned.
  *
  * See {@link module:engine/view/styles/utils~isLength}.
@@ -164,7 +164,7 @@ export function colorFieldValidator( value ) {
 export function lengthFieldValidator( value ) {
 	value = value.trim();
 
-	return isEmpty( value ) || isLength( value );
+	return isEmpty( value ) || isNumberString( value ) || isLength( value );
 }
 
 /**
@@ -232,4 +232,8 @@ export function fillToolbar( { view, icons, toolbar, labels, propertyName } ) {
 
 		toolbar.items.add( button );
 	}
+}
+
+function isNumberString( value ) {
+	return !Number.isNaN( parseFloat( value ) );
 }

--- a/src/ui/utils.js
+++ b/src/ui/utils.js
@@ -234,6 +234,10 @@ export function fillToolbar( { view, icons, toolbar, labels, propertyName } ) {
 	}
 }
 
+// A simple helper method to detect number strings.
+// I allows full number notation, so omitting 0 is not allowed:
 function isNumberString( value ) {
-	return !Number.isNaN( parseFloat( value ) );
+	const parsedValue = parseFloat( value );
+
+	return !Number.isNaN( parsedValue ) && value === String( parsedValue );
 }

--- a/tests/tablecellproperties/commands/tablecellborderwidthcommand.js
+++ b/tests/tablecellproperties/commands/tablecellborderwidthcommand.js
@@ -121,6 +121,62 @@ describe( 'table cell properties', () => {
 					sinon.assert.calledWith( spy, batch );
 				} );
 
+				it( 'should add default unit for numeric values (number passed)', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: 25 } );
+
+					assertTableCellStyle( editor, 'border-bottom:25px;border-left:25px;border-right:25px;border-top:25px;' );
+				} );
+
+				it( 'should add default unit for numeric values (string passed)', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: 25 } );
+
+					assertTableCellStyle( editor, 'border-bottom:25px;border-left:25px;border-right:25px;border-top:25px;' );
+				} );
+
+				it( 'should not add default unit for numeric values with unit', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: '25pt' } );
+
+					assertTableCellStyle( editor, 'border-bottom:25pt;border-left:25pt;border-right:25pt;border-top:25pt;' );
+				} );
+
+				it( 'should add default unit to floats (number passed)', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: 25.1 } );
+
+					assertTableCellStyle( editor, 'border-bottom:25.1px;border-left:25.1px;border-right:25.1px;border-top:25.1px;' );
+				} );
+
+				it( 'should add default unit to floats (string passed)', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: '0.1' } );
+
+					assertTableCellStyle( editor, 'border-bottom:0.1px;border-left:0.1px;border-right:0.1px;border-top:0.1px;' );
+				} );
+
+				it( 'should pass invalid values', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: 'bar' } );
+
+					assertTableCellStyle( editor, 'border-bottom:bar;border-left:bar;border-right:bar;border-top:bar;' );
+				} );
+
+				it( 'should pass invalid value (string passed, CSS float without leading 0)', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: '.2' } );
+
+					assertTableCellStyle( editor, 'border-bottom:.2;border-left:.2;border-right:.2;border-top:.2;' );
+				} );
+
 				describe( 'collapsed selection', () => {
 					it( 'should set selected table cell borderWidth to a passed value', () => {
 						setData( model, modelTable( [ [ 'foo[]' ] ] ) );

--- a/tests/tablecellproperties/commands/tablecellheightcommand.js
+++ b/tests/tablecellproperties/commands/tablecellheightcommand.js
@@ -96,6 +96,62 @@ describe( 'table cell properties', () => {
 					sinon.assert.calledWith( spy, batch );
 				} );
 
+				it( 'should add default unit for numeric values (number passed)', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: 25 } );
+
+					assertTableCellStyle( editor, 'height:25px;' );
+				} );
+
+				it( 'should add default unit for numeric values (string passed)', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: 25 } );
+
+					assertTableCellStyle( editor, 'height:25px;' );
+				} );
+
+				it( 'should not add default unit for numeric values with unit', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: '25pt' } );
+
+					assertTableCellStyle( editor, 'height:25pt;' );
+				} );
+
+				it( 'should add default unit to floats (number passed)', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: 25.1 } );
+
+					assertTableCellStyle( editor, 'height:25.1px;' );
+				} );
+
+				it( 'should add default unit to floats (string passed)', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: '0.1' } );
+
+					assertTableCellStyle( editor, 'height:0.1px;' );
+				} );
+
+				it( 'should pass invalid values', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: 'bar' } );
+
+					assertTableCellStyle( editor, 'height:bar;' );
+				} );
+
+				it( 'should pass invalid value (string passed, CSS float without leading 0)', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: '.2' } );
+
+					assertTableCellStyle( editor, 'height:.2;' );
+				} );
+
 				describe( 'collapsed selection', () => {
 					it( 'should set selected table cell height to a passed value', () => {
 						setData( model, modelTable( [ [ 'foo[]' ] ] ) );

--- a/tests/tablecellproperties/commands/tablecellpaddingcommand.js
+++ b/tests/tablecellproperties/commands/tablecellpaddingcommand.js
@@ -121,6 +121,62 @@ describe( 'table cell properties', () => {
 					sinon.assert.calledWith( spy, batch );
 				} );
 
+				it( 'should add default unit for numeric values (number passed)', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: 25 } );
+
+					assertTableCellStyle( editor, 'padding:25px;' );
+				} );
+
+				it( 'should add default unit for numeric values (string passed)', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: 25 } );
+
+					assertTableCellStyle( editor, 'padding:25px;' );
+				} );
+
+				it( 'should not add default unit for numeric values with unit', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: '25pt' } );
+
+					assertTableCellStyle( editor, 'padding:25pt;' );
+				} );
+
+				it( 'should add default unit to floats (number passed)', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: 25.1 } );
+
+					assertTableCellStyle( editor, 'padding:25.1px;' );
+				} );
+
+				it( 'should add default unit to floats (string passed)', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: '0.1' } );
+
+					assertTableCellStyle( editor, 'padding:0.1px;' );
+				} );
+
+				it( 'should pass invalid values', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: 'bar' } );
+
+					assertTableCellStyle( editor, 'padding:bar;' );
+				} );
+
+				it( 'should pass invalid value (string passed, CSS float without leading 0)', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: '.2' } );
+
+					assertTableCellStyle( editor, 'padding:.2;' );
+				} );
+
 				describe( 'collapsed selection', () => {
 					it( 'should set selected table cell padding to a passed value', () => {
 						setData( model, modelTable( [ [ 'foo[]' ] ] ) );

--- a/tests/tablecellproperties/commands/tablecellwidthcommand.js
+++ b/tests/tablecellproperties/commands/tablecellwidthcommand.js
@@ -96,6 +96,62 @@ describe( 'table cell properties', () => {
 					sinon.assert.calledWith( spy, batch );
 				} );
 
+				it( 'should add default unit for numeric values (number passed)', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: 25 } );
+
+					assertTableCellStyle( editor, 'width:25px;' );
+				} );
+
+				it( 'should add default unit for numeric values (string passed)', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: 25 } );
+
+					assertTableCellStyle( editor, 'width:25px;' );
+				} );
+
+				it( 'should not add default unit for numeric values with unit', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: '25pt' } );
+
+					assertTableCellStyle( editor, 'width:25pt;' );
+				} );
+
+				it( 'should add default unit to floats (number passed)', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: 25.1 } );
+
+					assertTableCellStyle( editor, 'width:25.1px;' );
+				} );
+
+				it( 'should add default unit to floats (string passed)', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: '0.1' } );
+
+					assertTableCellStyle( editor, 'width:0.1px;' );
+				} );
+
+				it( 'should pass invalid values', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: 'bar' } );
+
+					assertTableCellStyle( editor, 'width:bar;' );
+				} );
+
+				it( 'should pass invalid value (string passed, CSS float without leading 0)', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: '.2' } );
+
+					assertTableCellStyle( editor, 'width:.2;' );
+				} );
+
 				describe( 'collapsed selection', () => {
 					it( 'should set selected table cell width to a passed value', () => {
 						setData( model, modelTable( [ [ 'foo[]' ] ] ) );

--- a/tests/tableproperties/commands/tableborderwidthcommand.js
+++ b/tests/tableproperties/commands/tableborderwidthcommand.js
@@ -121,6 +121,62 @@ describe( 'table properties', () => {
 					sinon.assert.calledWith( spy, batch );
 				} );
 
+				it( 'should add default unit for numeric values (number passed)', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: 25 } );
+
+					assertTableStyle( editor, 'border-bottom:25px;border-left:25px;border-right:25px;border-top:25px;' );
+				} );
+
+				it( 'should add default unit for numeric values (string passed)', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: 25 } );
+
+					assertTableStyle( editor, 'border-bottom:25px;border-left:25px;border-right:25px;border-top:25px;' );
+				} );
+
+				it( 'should not add default unit for numeric values with unit', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: '25pt' } );
+
+					assertTableStyle( editor, 'border-bottom:25pt;border-left:25pt;border-right:25pt;border-top:25pt;' );
+				} );
+
+				it( 'should add default unit to floats (number passed)', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: 25.1 } );
+
+					assertTableStyle( editor, 'border-bottom:25.1px;border-left:25.1px;border-right:25.1px;border-top:25.1px;' );
+				} );
+
+				it( 'should add default unit to floats (string passed)', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: '0.1' } );
+
+					assertTableStyle( editor, 'border-bottom:0.1px;border-left:0.1px;border-right:0.1px;border-top:0.1px;' );
+				} );
+
+				it( 'should pass invalid values', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: 'bar' } );
+
+					assertTableStyle( editor, 'border-bottom:bar;border-left:bar;border-right:bar;border-top:bar;' );
+				} );
+
+				it( 'should pass invalid value (string passed, CSS float without leading 0)', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: '.2' } );
+
+					assertTableStyle( editor, 'border-bottom:.2;border-left:.2;border-right:.2;border-top:.2;' );
+				} );
+
 				describe( 'collapsed selection', () => {
 					it( 'should set selected table borderWidth to a passed value', () => {
 						setData( model, modelTable( [ [ 'foo[]' ] ] ) );

--- a/tests/tableproperties/commands/tableheightcommand.js
+++ b/tests/tableproperties/commands/tableheightcommand.js
@@ -96,6 +96,62 @@ describe( 'table properties', () => {
 					sinon.assert.calledWith( spy, batch );
 				} );
 
+				it( 'should add default unit for numeric values (number passed)', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: 25 } );
+
+					assertTableStyle( editor, 'height:25px;' );
+				} );
+
+				it( 'should add default unit for numeric values (string passed)', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: 25 } );
+
+					assertTableStyle( editor, 'height:25px;' );
+				} );
+
+				it( 'should not add default unit for numeric values with unit', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: '25pt' } );
+
+					assertTableStyle( editor, 'height:25pt;' );
+				} );
+
+				it( 'should add default unit to floats (number passed)', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: 25.1 } );
+
+					assertTableStyle( editor, 'height:25.1px;' );
+				} );
+
+				it( 'should add default unit to floats (string passed)', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: '0.1' } );
+
+					assertTableStyle( editor, 'height:0.1px;' );
+				} );
+
+				it( 'should pass invalid values', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: 'bar' } );
+
+					assertTableStyle( editor, 'height:bar;' );
+				} );
+
+				it( 'should pass invalid value (string passed, CSS float without leading 0)', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: '.2' } );
+
+					assertTableStyle( editor, 'height:.2;' );
+				} );
+
 				describe( 'collapsed selection', () => {
 					it( 'should set selected table height to a passed value', () => {
 						setData( model, modelTable( [ [ 'foo[]' ] ] ) );

--- a/tests/tableproperties/commands/tablewidthcommand.js
+++ b/tests/tableproperties/commands/tablewidthcommand.js
@@ -96,6 +96,62 @@ describe( 'table properties', () => {
 					sinon.assert.calledWith( spy, batch );
 				} );
 
+				it( 'should add default unit for numeric values (number passed)', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: 25 } );
+
+					assertTableStyle( editor, 'width:25px;' );
+				} );
+
+				it( 'should add default unit for numeric values (string passed)', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: 25 } );
+
+					assertTableStyle( editor, 'width:25px;' );
+				} );
+
+				it( 'should not add default unit for numeric values with unit', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: '25pt' } );
+
+					assertTableStyle( editor, 'width:25pt;' );
+				} );
+
+				it( 'should add default unit to floats (number passed)', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: 25.1 } );
+
+					assertTableStyle( editor, 'width:25.1px;' );
+				} );
+
+				it( 'should add default unit to floats (string passed)', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: '0.1' } );
+
+					assertTableStyle( editor, 'width:0.1px;' );
+				} );
+
+				it( 'should pass invalid values', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: 'bar' } );
+
+					assertTableStyle( editor, 'width:bar;' );
+				} );
+
+				it( 'should pass invalid value (string passed, CSS float without leading 0)', () => {
+					setData( model, modelTable( [ [ 'foo[]' ] ] ) );
+
+					command.execute( { value: '.2' } );
+
+					assertTableStyle( editor, 'width:.2;' );
+				} );
+
 				describe( 'collapsed selection', () => {
 					it( 'should set selected table width to a passed value', () => {
 						setData( model, modelTable( [ [ 'foo[]' ] ] ) );

--- a/tests/ui/utils.js
+++ b/tests/ui/utils.js
@@ -211,11 +211,11 @@ describe( 'UI Utils', () => {
 	} );
 
 	describe( 'colorFieldValidator()', () => {
-		it( 'should passe for an empty value', () => {
+		it( 'should pass for an empty value', () => {
 			expect( colorFieldValidator( '' ) ).to.be.true;
 		} );
 
-		it( 'should passe for white spaces', () => {
+		it( 'should pass for white spaces', () => {
 			expect( colorFieldValidator( '  ' ) ).to.be.true;
 		} );
 
@@ -233,11 +233,11 @@ describe( 'UI Utils', () => {
 	} );
 
 	describe( 'lengthFieldValidator()', () => {
-		it( 'should passe for an empty value', () => {
+		it( 'should pass for an empty value', () => {
 			expect( lengthFieldValidator( '' ) ).to.be.true;
 		} );
 
-		it( 'should passe for white spaces', () => {
+		it( 'should pass for white spaces', () => {
 			expect( lengthFieldValidator( '  ' ) ).to.be.true;
 		} );
 

--- a/tests/ui/utils.js
+++ b/tests/ui/utils.js
@@ -251,7 +251,12 @@ describe( 'UI Utils', () => {
 			expect( lengthFieldValidator( '1' ) ).to.be.true;
 			expect( lengthFieldValidator( '12.1' ) ).to.be.true;
 			expect( lengthFieldValidator( '0.125 ' ) ).to.be.true;
-			expect( lengthFieldValidator( '.1 ' ) ).to.be.true;
+		} );
+
+		it( 'should not pass for invalid number values', () => {
+			expect( lengthFieldValidator( '.1 ' ) ).to.be.false;
+			expect( lengthFieldValidator( '45. ' ) ).to.be.false;
+			expect( lengthFieldValidator( '45.1.1 ' ) ).to.be.false;
 		} );
 
 		it( 'should pass for lengths surrounded by white spaces', () => {

--- a/tests/ui/utils.js
+++ b/tests/ui/utils.js
@@ -247,6 +247,13 @@ describe( 'UI Utils', () => {
 			expect( lengthFieldValidator( ' 12em ' ) ).to.be.true;
 		} );
 
+		it( 'should pass for number without unit', () => {
+			expect( lengthFieldValidator( '1' ) ).to.be.true;
+			expect( lengthFieldValidator( '12.1' ) ).to.be.true;
+			expect( lengthFieldValidator( '0.125 ' ) ).to.be.true;
+			expect( lengthFieldValidator( '.1 ' ) ).to.be.true;
+		} );
+
 		it( 'should pass for lengths surrounded by white spaces', () => {
 			expect( lengthFieldValidator( '3px ' ) ).to.be.true;
 			expect( lengthFieldValidator( ' 12em ' ) ).to.be.true;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Table and table cell properties commands add default `'px'` unit to numeric values. Closes ckeditor/ckeditor5#6098.

---

### Additional information

I've added this behavior to the commands:
- `TableWidthCommand`
- `TableHeightCommand`
- `TableCellWidthCommand`
- `TableCellHeightCommand`
- `TableCellPaddingCommand`
- `TableCellBorderWidthCommand`
- `TableBorderWidthCommand`

The logic behind this (`addDefaultUnitToNumericValue()` method) is to add default unit only to numeric values. Other values are passed as-is. This is done because other commands also work like this. Value validation is done in the UI.