### PR TITLE
Fix style removal conversion.

### DIFF
--- a/src/converters/tableproperties.js
+++ b/src/converters/tableproperties.js
@@ -110,7 +110,7 @@ export function downcastTableAttribute( conversion, modelAttribute, styleName ) 
 		if ( attributeNewValue ) {
 			writer.setStyle( styleName, attributeNewValue, table );
 		} else {
-			writer.removeAttribute( styleName, table );
+			writer.removeStyle( styleName, table );
 		}
 	} ) );
 }

--- a/src/tableproperties/tablepropertiesediting.js
+++ b/src/tableproperties/tablepropertiesediting.js
@@ -11,13 +11,13 @@ import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import { addBorderRules } from '@ckeditor/ckeditor5-engine/src/view/styles/border';
 import { addBackgroundRules } from '@ckeditor/ckeditor5-engine/src/view/styles/background';
 
-import TableEditing from './../tableediting';
+import TableEditing from '../tableediting';
 import {
 	downcastAttributeToStyle,
 	downcastTableAttribute,
 	upcastBorderStyles,
 	upcastStyleToAttribute
-} from './../converters/tableproperties';
+} from '../converters/tableproperties';
 import TableBackgroundColorCommand from './commands/tablebackgroundcolorcommand';
 import TableBorderColorCommand from './commands/tablebordercolorcommand';
 import TableBorderStyleCommand from './commands/tableborderstylecommand';
@@ -154,6 +154,7 @@ function enableAlignmentProperty( schema, conversion ) {
 				value: viewElement => viewElement.getAttribute( 'align' )
 			}
 		} );
+
 	conversion.for( 'downcast' ).add( dispatcher => dispatcher.on( 'attribute:alignment:table', ( evt, data, conversionApi ) => {
 		const { item, attributeNewValue } = data;
 		const { mapper, writer } = conversionApi;

--- a/tests/_utils/utils.js
+++ b/tests/_utils/utils.js
@@ -317,7 +317,7 @@ export function assertTableStyle( editor, tableStyle, figureStyle ) {
  * An assertion helper for testing the `<td>` style attribute.
  *
  * @param {module:core/editor/editor~Editor} editor
- * @param {String} tableCellStyle A style to assert on td.
+ * @param {String} [tableCellStyle=''] A style to assert on td.
  */
 export function assertTableCellStyle( editor, tableCellStyle ) {
 	assertEqualMarkup( editor.getData(),

--- a/tests/tablecellproperties/tablecellpropertiesediting.js
+++ b/tests/tablecellproperties/tablecellpropertiesediting.js
@@ -23,7 +23,7 @@ import { setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-util
 import { assertEqualMarkup } from '@ckeditor/ckeditor5-utils/tests/_utils/utils';
 import { assertTableCellStyle, assertTRBLAttribute } from '../_utils/utils';
 
-describe.only( 'table cell properties', () => {
+describe( 'table cell properties', () => {
 	describe( 'TableCellPropertiesEditing', () => {
 		let editor, model;
 

--- a/tests/tablecellproperties/tablecellpropertiesediting.js
+++ b/tests/tablecellproperties/tablecellpropertiesediting.js
@@ -23,7 +23,7 @@ import { setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-util
 import { assertEqualMarkup } from '@ckeditor/ckeditor5-utils/tests/_utils/utils';
 import { assertTableCellStyle, assertTRBLAttribute } from '../_utils/utils';
 
-describe( 'table cell properties', () => {
+describe.only( 'table cell properties', () => {
 	describe( 'TableCellPropertiesEditing', () => {
 		let editor, model;
 
@@ -564,6 +564,24 @@ describe( 'table cell properties', () => {
 
 					assertTableCellStyle( editor, 'background-color:#f00;' );
 				} );
+
+				it( 'should downcast backgroundColor removal', () => {
+					model.change( writer => writer.setAttribute( 'backgroundColor', '#f00', tableCell ) );
+
+					model.change( writer => writer.removeAttribute( 'backgroundColor', tableCell ) );
+
+					assertTableCellStyle( editor );
+				} );
+
+				it( 'should downcast backgroundColor change', () => {
+					model.change( writer => writer.setAttribute( 'backgroundColor', '#f00', tableCell ) );
+
+					assertTableCellStyle( editor, 'background-color:#f00;' );
+
+					model.change( writer => writer.setAttribute( 'backgroundColor', '#ba7', tableCell ) );
+
+					assertTableCellStyle( editor, 'background-color:#ba7;' );
+				} );
 			} );
 		} );
 
@@ -736,6 +754,24 @@ describe( 'table cell properties', () => {
 
 					assertTableCellStyle( editor, 'padding:2px 3px 4px 5px;' );
 				} );
+
+				it( 'should downcast padding removal', () => {
+					model.change( writer => writer.setAttribute( 'padding', '1337px', tableCell ) );
+
+					model.change( writer => writer.removeAttribute( 'padding', tableCell ) );
+
+					assertTableCellStyle( editor );
+				} );
+
+				it( 'should downcast padding change', () => {
+					model.change( writer => writer.setAttribute( 'padding', '1337px', tableCell ) );
+
+					assertTableCellStyle( editor, 'padding:1337px;' );
+
+					model.change( writer => writer.setAttribute( 'padding', '1410em', tableCell ) );
+
+					assertTableCellStyle( editor, 'padding:1410em;' );
+				} );
 			} );
 		} );
 
@@ -779,6 +815,24 @@ describe( 'table cell properties', () => {
 						'<figure class="table"><table><tbody><tr><td style="width:20px;">foo</td></tr></tbody></table></figure>'
 					);
 				} );
+
+				it( 'should downcast width removal', () => {
+					model.change( writer => writer.setAttribute( 'width', '1337px', tableCell ) );
+
+					model.change( writer => writer.removeAttribute( 'width', tableCell ) );
+
+					assertTableCellStyle( editor );
+				} );
+
+				it( 'should downcast width change', () => {
+					model.change( writer => writer.setAttribute( 'width', '1337px', tableCell ) );
+
+					assertTableCellStyle( editor, 'width:1337px;' );
+
+					model.change( writer => writer.setAttribute( 'width', '1410em', tableCell ) );
+
+					assertTableCellStyle( editor, 'width:1410em;' );
+				} );
 			} );
 		} );
 
@@ -821,6 +875,24 @@ describe( 'table cell properties', () => {
 						editor.getData(),
 						'<figure class="table"><table><tbody><tr><td style="height:20px;">foo</td></tr></tbody></table></figure>'
 					);
+				} );
+
+				it( 'should downcast height removal', () => {
+					model.change( writer => writer.setAttribute( 'height', '1337px', tableCell ) );
+
+					model.change( writer => writer.removeAttribute( 'height', tableCell ) );
+
+					assertTableCellStyle( editor );
+				} );
+
+				it( 'should downcast height change', () => {
+					model.change( writer => writer.setAttribute( 'height', '1337px', tableCell ) );
+
+					assertTableCellStyle( editor, 'height:1337px;' );
+
+					model.change( writer => writer.setAttribute( 'height', '1410em', tableCell ) );
+
+					assertTableCellStyle( editor, 'height:1410em;' );
 				} );
 			} );
 		} );

--- a/tests/tableproperties/tablepropertiesediting.js
+++ b/tests/tableproperties/tablepropertiesediting.js
@@ -22,7 +22,7 @@ import { assertEqualMarkup } from '@ckeditor/ckeditor5-utils/tests/_utils/utils'
 import { assertTableStyle, assertTRBLAttribute } from '../_utils/utils';
 
 describe( 'table properties', () => {
-	describe.only( 'TablePropertiesEditing', () => {
+	describe( 'TablePropertiesEditing', () => {
 		let editor, model;
 
 		beforeEach( () => {

--- a/tests/tableproperties/tablepropertiesediting.js
+++ b/tests/tableproperties/tablepropertiesediting.js
@@ -22,7 +22,7 @@ import { assertEqualMarkup } from '@ckeditor/ckeditor5-utils/tests/_utils/utils'
 import { assertTableStyle, assertTRBLAttribute } from '../_utils/utils';
 
 describe( 'table properties', () => {
-	describe( 'TablePropertiesEditing', () => {
+	describe.only( 'TablePropertiesEditing', () => {
 		let editor, model;
 
 		beforeEach( () => {
@@ -513,6 +513,24 @@ describe( 'table properties', () => {
 
 					assertTableStyle( editor, 'background-color:#f00;' );
 				} );
+
+				it( 'should downcast backgroundColor removal', () => {
+					model.change( writer => writer.setAttribute( 'backgroundColor', '#f00', table ) );
+
+					model.change( writer => writer.removeAttribute( 'backgroundColor', table ) );
+
+					assertTableStyle( editor );
+				} );
+
+				it( 'should downcast backgroundColor change', () => {
+					model.change( writer => writer.setAttribute( 'backgroundColor', '#f00', table ) );
+
+					assertTableStyle( editor, 'background-color:#f00;' );
+
+					model.change( writer => writer.setAttribute( 'backgroundColor', '#ba7', table ) );
+
+					assertTableStyle( editor, 'background-color:#ba7;' );
+				} );
 			} );
 		} );
 
@@ -549,6 +567,24 @@ describe( 'table properties', () => {
 
 					assertTableStyle( editor, null, 'width:1337px;' );
 				} );
+
+				it( 'should downcast width removal', () => {
+					model.change( writer => writer.setAttribute( 'width', '1337px', table ) );
+
+					model.change( writer => writer.removeAttribute( 'width', table ) );
+
+					assertTableStyle( editor );
+				} );
+
+				it( 'should downcast width change', () => {
+					model.change( writer => writer.setAttribute( 'width', '1337px', table ) );
+
+					assertTableStyle( editor, null, 'width:1337px;' );
+
+					model.change( writer => writer.setAttribute( 'width', '1410em', table ) );
+
+					assertTableStyle( editor, null, 'width:1410em;' );
+				} );
 			} );
 		} );
 
@@ -584,6 +620,24 @@ describe( 'table properties', () => {
 					model.change( writer => writer.setAttribute( 'height', '1337px', table ) );
 
 					assertTableStyle( editor, null, 'height:1337px;' );
+				} );
+
+				it( 'should downcast height removal', () => {
+					model.change( writer => writer.setAttribute( 'height', '1337px', table ) );
+
+					model.change( writer => writer.removeAttribute( 'height', table ) );
+
+					assertTableStyle( editor );
+				} );
+
+				it( 'should downcast height change', () => {
+					model.change( writer => writer.setAttribute( 'height', '1337px', table ) );
+
+					assertTableStyle( editor, null, 'height:1337px;' );
+
+					model.change( writer => writer.setAttribute( 'height', '1410em', table ) );
+
+					assertTableStyle( editor, null, 'height:1410em;' );
 				} );
 			} );
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Fix style removal conversion. Closes ckeditor/ckeditor5#6183.

---

### Additional information

* There was a "typo" in the converters `writer.removeAttribute()` vs `writer.removeStyle()`.
* More tests aded.
