### PR TITLE
I/6150: Make table cell properties UI aware of mult-cell selection.

### DIFF
--- a/src/commands/utils.js
+++ b/src/commands/utils.js
@@ -30,20 +30,6 @@ export function findAncestor( parentName, positionOrElement ) {
 }
 
 /**
- * Returns the first selected table cell from a multi-cell or in-cell selection.
- *
- *		const tableCell = getSelectedTableCell( editor.model.document.selection.getFirstPosition() );
- *
- * @param {module:engine/model/position~Position} position Document position.
- * @returns {module:engine/model/element~Element}
- */
-export function getSelectedTableCell( position ) {
-	const isTableCellSelected = position.nodeAfter && position.nodeAfter.is( 'tableCell' );
-
-	return isTableCellSelected ? position.nodeAfter : findAncestor( 'tableCell', position );
-}
-
-/**
  * A common method to update the numeric value. If a value is the default one, it will be unset.
  *
  * @param {String} key An attribute key.

--- a/src/tablecellproperties/commands/tablecellpropertycommand.js
+++ b/src/tablecellproperties/commands/tablecellpropertycommand.js
@@ -97,7 +97,8 @@ export default class TableCellPropertyCommand extends Command {
 	}
 
 	/**
-	 * Returns a single value for all selected table cells. If the value is the same for all cells, it will be returned (`undefined` otherwise).
+	 * Returns a single value for all selected table cells. If the value is the same for all cells,
+	 * it will be returned (`undefined` otherwise).
 	 *
 	 * @param {Array.<module:engine/model/element~Element>} tableCell
 	 * @returns {*}

--- a/src/ui/utils.js
+++ b/src/ui/utils.js
@@ -14,7 +14,7 @@ import Model from '@ckeditor/ckeditor5-ui/src/model';
 import ColorInputView from './colorinputview';
 import { isColor, isLength, isPercentage } from '@ckeditor/ckeditor5-engine/src/view/styles/utils';
 import { getTableWidgetAncestor } from '../utils';
-import { findAncestor, getSelectedTableCell } from '../commands/utils';
+import { findAncestor } from '../commands/utils';
 
 const DEFAULT_BALLOON_POSITIONS = BalloonPanelView.defaultPositions;
 const BALLOON_POSITIONS = [
@@ -81,7 +81,7 @@ export function getBalloonTablePositionData( editor ) {
  * @returns {module:utils/dom/position~Options}
  */
 export function getBalloonCellPositionData( editor ) {
-	const modelTableCell = getSelectedTableCell( editor.model.document.selection.getFirstPosition() );
+	const modelTableCell = getTableCellAtPosition( editor.model.document.selection.getFirstPosition() );
 	const viewTableCell = editor.editing.mapper.toViewElement( modelTableCell );
 
 	return {
@@ -466,4 +466,14 @@ function colorConfigToColorGridDefinitions( colorConfig ) {
 			hasBorder: item.hasBorder
 		}
 	} ) );
+}
+
+// Returns the first selected table cell from a multi-cell or in-cell selection.
+//
+// @param {module:engine/model/position~Position} position Document position.
+// @returns {module:engine/model/element~Element}
+function getTableCellAtPosition( position ) {
+	const isTableCellSelected = position.nodeAfter && position.nodeAfter.is( 'tableCell' );
+
+	return isTableCellSelected ? position.nodeAfter : findAncestor( 'tableCell', position );
 }

--- a/tests/manual/tableselection.html
+++ b/tests/manual/tableselection.html
@@ -52,7 +52,13 @@
 					<td>k</td>
 					<td>l</td>
 					<td><strong>m</strong></td>
-					<td>n</td>
+					<td>
+						<p>n</p>
+						<figure class="image image-style-side">
+							<img src="sample.jpg" />
+							<figcaption>Caption!</figcaption>
+						</figure>
+					</td>
 					<td>o</td>
 				</tr>
 				<tr>

--- a/tests/manual/tableselection.js
+++ b/tests/manual/tableselection.js
@@ -31,6 +31,9 @@ function createEditor( target, inspectorName ) {
 				'bulletedList', 'numberedList', 'blockQuote', '|',
 				'undo', 'redo'
 			],
+			image: {
+				toolbar: [ 'imageStyle:full', 'imageStyle:side', '|', 'imageTextAlternative' ]
+			},
 			table: {
 				contentToolbar: [ 'tableColumn', 'tableRow', 'mergeTableCells', 'tableProperties', 'tableCellProperties' ]
 			}

--- a/tests/tablecellproperties/commands/tablecellbackgroundcolorcommand.js
+++ b/tests/tablecellproperties/commands/tablecellbackgroundcolorcommand.js
@@ -57,7 +57,7 @@ describe( 'table cell properties', () => {
 				} );
 
 				describe( 'multi-cell selection', () => {
-					it( 'should be true is selection has table cells', () => {
+					it( 'should be true if the selection contains some table cells', () => {
 						setData( model, modelTable( [
 							[ { contents: '00', isSelected: true }, '01' ],
 							[ '10', { contents: '11', isSelected: true } ]

--- a/tests/tablecellproperties/commands/tablecellbackgroundcolorcommand.js
+++ b/tests/tablecellproperties/commands/tablecellbackgroundcolorcommand.js
@@ -239,7 +239,7 @@ describe( 'table cell properties', () => {
 						] ) );
 					} );
 
-					it( 'should remove backgroundColor from a selected table cell if no value is passed', () => {
+					it( 'should remove "backgroundColor" from a selected table cell if no value is passed', () => {
 						setData( model, modelTable( [
 							[ { contents: '00', isSelected: true, backgroundColor: '#f00' }, '01' ],
 							[ '10', { contents: '11', isSelected: true, backgroundColor: '#f00' } ]

--- a/tests/tablecellproperties/commands/tablecellbackgroundcolorcommand.js
+++ b/tests/tablecellproperties/commands/tablecellbackgroundcolorcommand.js
@@ -143,7 +143,7 @@ describe( 'table cell properties', () => {
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be set if all table cell has the same backgroundColor property value', () => {
+					it( 'should be set if all table cell have the same "backgroundColor" property value', () => {
 						setData( model, modelTable( [
 							[
 								{ contents: '00', isSelected: true, backgroundColor: '#f00' },

--- a/tests/tablecellproperties/commands/tablecellbackgroundcolorcommand.js
+++ b/tests/tablecellproperties/commands/tablecellbackgroundcolorcommand.js
@@ -128,7 +128,7 @@ describe( 'table cell properties', () => {
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be undefined if one of selected table cells has different backgroundColor property value', () => {
+					it( 'should be undefined if one of selected table cells has a different "backgroundColor" property value', () => {
 						setData( model, modelTable( [
 							[
 								{ contents: '00', isSelected: true, backgroundColor: '#f00' },

--- a/tests/tablecellproperties/commands/tablecellbackgroundcolorcommand.js
+++ b/tests/tablecellproperties/commands/tablecellbackgroundcolorcommand.js
@@ -230,7 +230,7 @@ describe( 'table cell properties', () => {
 						] ) );
 					} );
 
-					it( 'should set selected table cell backgroundColor to a passed value', () => {
+					it( 'should set the "backgroundColor" attribute value of selected table cells', () => {
 						command.execute( { value: '#f00' } );
 
 						assertEqualMarkup( editor.getData(), viewTable( [

--- a/tests/tablecellproperties/commands/tablecellbordercolorcommand.js
+++ b/tests/tablecellproperties/commands/tablecellbordercolorcommand.js
@@ -57,7 +57,7 @@ describe( 'table cell properties', () => {
 				} );
 
 				describe( 'multi-cell selection', () => {
-					it( 'should be true is selection has table cells', () => {
+					it( 'should be true if the selection contains some table cells', () => {
 						setData( model, modelTable( [
 							[ { contents: '00', isSelected: true }, '01' ],
 							[ '10', { contents: '11', isSelected: true } ]

--- a/tests/tablecellproperties/commands/tablecellbordercolorcommand.js
+++ b/tests/tablecellproperties/commands/tablecellbordercolorcommand.js
@@ -138,7 +138,7 @@ describe( 'table cell properties', () => {
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be undefined if only some table cell has a borderColor property', () => {
+					it( 'should be undefined if only some table cells have the "borderColor" property', () => {
 						setData( model, modelTable( [
 							[
 								{ contents: '00', isSelected: true, borderColor: '#f00' },

--- a/tests/tablecellproperties/commands/tablecellbordercolorcommand.js
+++ b/tests/tablecellproperties/commands/tablecellbordercolorcommand.js
@@ -153,7 +153,7 @@ describe( 'table cell properties', () => {
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be undefined if one of selected table cells has different borderColor property value', () => {
+					it( 'should be undefined if one of selected table cells has a different "borderColor" property value', () => {
 						setData( model, modelTable( [
 							[
 								{ contents: '00', isSelected: true, borderColor: '#f00' },

--- a/tests/tablecellproperties/commands/tablecellbordercolorcommand.js
+++ b/tests/tablecellproperties/commands/tablecellbordercolorcommand.js
@@ -255,7 +255,7 @@ describe( 'table cell properties', () => {
 						] ) );
 					} );
 
-					it( 'should set selected table cell borderColor to a passed value', () => {
+					it( 'should set the "borderColor" attribute value of selected table cells', () => {
 						command.execute( { value: '#f00' } );
 
 						assertEqualMarkup( editor.getData(), viewTable( [

--- a/tests/tablecellproperties/commands/tablecellbordercolorcommand.js
+++ b/tests/tablecellproperties/commands/tablecellbordercolorcommand.js
@@ -264,7 +264,7 @@ describe( 'table cell properties', () => {
 						] ) );
 					} );
 
-					it( 'should remove borderColor from a selected table cell if no value is passed', () => {
+					it( 'should remove "borderColor" from the selected table cell if no value is passed', () => {
 						setData( model, modelTable( [
 							[ { contents: '00', isSelected: true, borderColor: '#f00' }, '01' ],
 							[ '10', { contents: '11', isSelected: true, borderColor: '#f00' } ]

--- a/tests/tablecellproperties/commands/tablecellbordercolorcommand.js
+++ b/tests/tablecellproperties/commands/tablecellbordercolorcommand.js
@@ -168,7 +168,7 @@ describe( 'table cell properties', () => {
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be set if all table cell has the same borderColor property value', () => {
+					it( 'should be set if all table cells have the same "borderColor" property value', () => {
 						setData( model, modelTable( [
 							[
 								{ contents: '00', isSelected: true, borderColor: '#f00' },

--- a/tests/tablecellproperties/commands/tablecellbordercolorcommand.js
+++ b/tests/tablecellproperties/commands/tablecellbordercolorcommand.js
@@ -123,7 +123,7 @@ describe( 'table cell properties', () => {
 				} );
 
 				describe( 'multi-cell selection', () => {
-					it( 'should be undefined if no table cell has a borderColor property', () => {
+					it( 'should be undefined if no table cells have the "borderColor" property', () => {
 						setData( model, modelTable( [
 							[
 								{ contents: '00', isSelected: true },

--- a/tests/tablecellproperties/commands/tablecellborderstylecommand.js
+++ b/tests/tablecellproperties/commands/tablecellborderstylecommand.js
@@ -57,7 +57,7 @@ describe( 'table cell properties', () => {
 				} );
 
 				describe( 'multi-cell selection', () => {
-					it( 'should be true is selection has table cells', () => {
+					it( 'should be true if the selection contains some table cells', () => {
 						setData( model, modelTable( [
 							[ { contents: '00', isSelected: true }, '01' ],
 							[ '10', { contents: '11', isSelected: true } ]

--- a/tests/tablecellproperties/commands/tablecellborderstylecommand.js
+++ b/tests/tablecellproperties/commands/tablecellborderstylecommand.js
@@ -168,7 +168,7 @@ describe( 'table cell properties', () => {
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be set if all table cell has the same borderStyle property value', () => {
+					it( 'should be set if all table cells have the same "borderStyle" property value', () => {
 						setData( model, modelTable( [
 							[
 								{ contents: '00', isSelected: true, borderStyle: 'solid' },

--- a/tests/tablecellproperties/commands/tablecellborderstylecommand.js
+++ b/tests/tablecellproperties/commands/tablecellborderstylecommand.js
@@ -255,7 +255,7 @@ describe( 'table cell properties', () => {
 						] ) );
 					} );
 
-					it( 'should set selected table cell borderStyle to a passed value', () => {
+					it( 'should set the "borderStyle" attribute value of selected table cells', () => {
 						command.execute( { value: 'solid' } );
 
 						assertEqualMarkup( editor.getData(), viewTable( [

--- a/tests/tablecellproperties/commands/tablecellborderstylecommand.js
+++ b/tests/tablecellproperties/commands/tablecellborderstylecommand.js
@@ -270,7 +270,7 @@ describe( 'table cell properties', () => {
 						] ) );
 					} );
 
-					it( 'should remove borderStyle from a selected table cell if no value is passed', () => {
+					it( 'should remove "borderStyle" from selected table cells if no value is passed', () => {
 						setData( model, modelTable( [
 							[ { contents: '00', isSelected: true, borderStyle: 'solid' }, '01' ],
 							[ '10', { contents: '11', isSelected: true, borderStyle: 'solid' } ]

--- a/tests/tablecellproperties/commands/tablecellborderstylecommand.js
+++ b/tests/tablecellproperties/commands/tablecellborderstylecommand.js
@@ -153,7 +153,7 @@ describe( 'table cell properties', () => {
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be undefined if one of selected table cells has different borderStyle property value', () => {
+					it( 'should be undefined if one of selected table cells has a different "borderStyle" property value', () => {
 						setData( model, modelTable( [
 							[
 								{ contents: '00', isSelected: true, borderStyle: 'solid' },

--- a/tests/tablecellproperties/commands/tablecellborderstylecommand.js
+++ b/tests/tablecellproperties/commands/tablecellborderstylecommand.js
@@ -138,7 +138,7 @@ describe( 'table cell properties', () => {
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be undefined if only some table cell has a borderStyle property', () => {
+					it( 'should be undefined if only some table cells have the "borderStyle" property', () => {
 						setData( model, modelTable( [
 							[
 								{ contents: '00', isSelected: true, borderStyle: 'solid' },

--- a/tests/tablecellproperties/commands/tablecellborderstylecommand.js
+++ b/tests/tablecellproperties/commands/tablecellborderstylecommand.js
@@ -123,7 +123,7 @@ describe( 'table cell properties', () => {
 				} );
 
 				describe( 'multi-cell selection', () => {
-					it( 'should be undefined if no table cell has a borderStyle property', () => {
+					it( 'should be undefined if no table cells have the "borderStyle" property', () => {
 						setData( model, modelTable( [
 							[
 								{ contents: '00', isSelected: true },

--- a/tests/tablecellproperties/commands/tablecellborderwidthcommand.js
+++ b/tests/tablecellproperties/commands/tablecellborderwidthcommand.js
@@ -57,7 +57,7 @@ describe( 'table cell properties', () => {
 				} );
 
 				describe( 'multi-cell selection', () => {
-					it( 'should be true is selection has table cells', () => {
+					it( 'should be true if the selection contains some table cells', () => {
 						setData( model, modelTable( [
 							[ { contents: '00', isSelected: true }, '01' ],
 							[ '10', { contents: '11', isSelected: true } ]

--- a/tests/tablecellproperties/commands/tablecellborderwidthcommand.js
+++ b/tests/tablecellproperties/commands/tablecellborderwidthcommand.js
@@ -138,7 +138,7 @@ describe( 'table cell properties', () => {
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be undefined if only some table cell has a borderWidth property', () => {
+					it( 'should be undefined if only some table cells have the "borderWidth" property', () => {
 						setData( model, modelTable( [
 							[
 								{ contents: '00', isSelected: true, borderWidth: '1px' },

--- a/tests/tablecellproperties/commands/tablecellborderwidthcommand.js
+++ b/tests/tablecellproperties/commands/tablecellborderwidthcommand.js
@@ -326,7 +326,7 @@ describe( 'table cell properties', () => {
 						] ) );
 					} );
 
-					it( 'should remove borderWidth from a selected table cell if no value is passed', () => {
+					it( 'should remove "borderWidth" from selected table cells if no value is passed', () => {
 						setData( model, modelTable( [
 							[ { contents: '00', isSelected: true, borderWidth: '1px' }, '01' ],
 							[ '10', { contents: '11', isSelected: true, borderWidth: '1px' } ]

--- a/tests/tablecellproperties/commands/tablecellborderwidthcommand.js
+++ b/tests/tablecellproperties/commands/tablecellborderwidthcommand.js
@@ -153,7 +153,7 @@ describe( 'table cell properties', () => {
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be undefined if one of selected table cells has different borderWidth property value', () => {
+					it( 'should be undefined if one of selected table cells has a different "borderWidth" property value', () => {
 						setData( model, modelTable( [
 							[
 								{ contents: '00', isSelected: true, borderWidth: '1px' },

--- a/tests/tablecellproperties/commands/tablecellborderwidthcommand.js
+++ b/tests/tablecellproperties/commands/tablecellborderwidthcommand.js
@@ -168,7 +168,7 @@ describe( 'table cell properties', () => {
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be set if all table cell has the same borderWidth property value', () => {
+					it( 'should be set if all table cells have the same "borderWidth" property value', () => {
 						setData( model, modelTable( [
 							[
 								{ contents: '00', isSelected: true, borderWidth: '1px' },

--- a/tests/tablecellproperties/commands/tablecellborderwidthcommand.js
+++ b/tests/tablecellproperties/commands/tablecellborderwidthcommand.js
@@ -123,7 +123,7 @@ describe( 'table cell properties', () => {
 				} );
 
 				describe( 'multi-cell selection', () => {
-					it( 'should be undefined if no table cell has a borderWidth property', () => {
+					it( 'should be undefined if no table cells have the "borderWidth" property', () => {
 						setData( model, modelTable( [
 							[
 								{ contents: '00', isSelected: true },

--- a/tests/tablecellproperties/commands/tablecellborderwidthcommand.js
+++ b/tests/tablecellproperties/commands/tablecellborderwidthcommand.js
@@ -311,7 +311,7 @@ describe( 'table cell properties', () => {
 						] ) );
 					} );
 
-					it( 'should set selected table cell borderWidth to a passed value', () => {
+					it( 'should set the "borderWidth" attribute value of selected table cells', () => {
 						command.execute( { value: '1px' } );
 
 						assertEqualMarkup( editor.getData(), viewTable( [

--- a/tests/tablecellproperties/commands/tablecellheightcommand.js
+++ b/tests/tablecellproperties/commands/tablecellheightcommand.js
@@ -57,7 +57,7 @@ describe( 'table cell properties', () => {
 				} );
 
 				describe( 'multi-cell selection', () => {
-					it( 'should be true is selection has table cells', () => {
+					it( 'should be true if the selection contains some table cells', () => {
 						setData( model, modelTable( [
 							[ { contents: '00', isSelected: true }, '01' ],
 							[ '10', { contents: '11', isSelected: true } ]

--- a/tests/tablecellproperties/commands/tablecellheightcommand.js
+++ b/tests/tablecellproperties/commands/tablecellheightcommand.js
@@ -286,7 +286,7 @@ describe( 'table cell properties', () => {
 						] ) );
 					} );
 
-					it( 'should set selected table cell height to a passed value', () => {
+					it( 'should set the "height" attribute value of selected table cells', () => {
 						command.execute( { value: '100px' } );
 
 						assertEqualMarkup( editor.getData(), viewTable( [

--- a/tests/tablecellproperties/commands/tablecellheightcommand.js
+++ b/tests/tablecellproperties/commands/tablecellheightcommand.js
@@ -128,7 +128,7 @@ describe( 'table cell properties', () => {
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be undefined if one of selected table cells has different height property value', () => {
+					it( 'should be undefined if one of selected table cells has a different "height" property value', () => {
 						setData( model, modelTable( [
 							[
 								{ contents: '00', isSelected: true, height: '100px' },

--- a/tests/tablecellproperties/commands/tablecellheightcommand.js
+++ b/tests/tablecellproperties/commands/tablecellheightcommand.js
@@ -113,7 +113,7 @@ describe( 'table cell properties', () => {
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be undefined if only some table cell has a height property', () => {
+					it( 'should be undefined if only some table cells have the "height" property', () => {
 						setData( model, modelTable( [
 							[
 								{ contents: '00', isSelected: true, height: '100px' },

--- a/tests/tablecellproperties/commands/tablecellheightcommand.js
+++ b/tests/tablecellproperties/commands/tablecellheightcommand.js
@@ -143,7 +143,7 @@ describe( 'table cell properties', () => {
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be set if all table cell has the same height property value', () => {
+					it( 'should be set if all table cell have the same "height" property value', () => {
 						setData( model, modelTable( [
 							[
 								{ contents: '00', isSelected: true, height: '100px' },

--- a/tests/tablecellproperties/commands/tablecellheightcommand.js
+++ b/tests/tablecellproperties/commands/tablecellheightcommand.js
@@ -295,7 +295,7 @@ describe( 'table cell properties', () => {
 						] ) );
 					} );
 
-					it( 'should remove height from a selected table cell if no value is passed', () => {
+					it( 'should remove "height" from selected table cells if no value is passed', () => {
 						setData( model, modelTable( [
 							[ { contents: '00', isSelected: true, height: '100px' }, '01' ],
 							[ '10', { contents: '11', isSelected: true, height: '100px' } ]

--- a/tests/tablecellproperties/commands/tablecellheightcommand.js
+++ b/tests/tablecellproperties/commands/tablecellheightcommand.js
@@ -98,7 +98,7 @@ describe( 'table cell properties', () => {
 				} );
 
 				describe( 'multi-cell selection', () => {
-					it( 'should be undefined if no table cell has a height property', () => {
+					it( 'should be undefined if no table cell have the "height" property', () => {
 						setData( model, modelTable( [
 							[
 								{ contents: '00', isSelected: true },

--- a/tests/tablecellproperties/commands/tablecellhorizontalalignmentcommand.js
+++ b/tests/tablecellproperties/commands/tablecellhorizontalalignmentcommand.js
@@ -98,7 +98,7 @@ describe( 'table cell properties', () => {
 				} );
 
 				describe( 'multi-cell selection', () => {
-					it( 'should be undefined if no table cell has a horizontalAlignment property', () => {
+					it( 'should be undefined if no table cells have the "horizontalAlignment" property', () => {
 						setData( model, modelTable( [
 							[
 								{ contents: '00', isSelected: true },

--- a/tests/tablecellproperties/commands/tablecellhorizontalalignmentcommand.js
+++ b/tests/tablecellproperties/commands/tablecellhorizontalalignmentcommand.js
@@ -57,7 +57,7 @@ describe( 'table cell properties', () => {
 				} );
 
 				describe( 'multi-cell selection', () => {
-					it( 'should be true is selection has table cells', () => {
+					it( 'should be true if the selection contains some table cells', () => {
 						setData( model, modelTable( [
 							[ { contents: '00', isSelected: true }, '01' ],
 							[ '10', { contents: '11', isSelected: true } ]

--- a/tests/tablecellproperties/commands/tablecellhorizontalalignmentcommand.js
+++ b/tests/tablecellproperties/commands/tablecellhorizontalalignmentcommand.js
@@ -113,7 +113,7 @@ describe( 'table cell properties', () => {
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be undefined if only some table cell has a horizontalAlignment property', () => {
+					it( 'should be undefined if only some table cells have the "horizontalAlignment" property', () => {
 						setData( model, modelTable( [
 							[
 								{ contents: '00', isSelected: true, horizontalAlignment: 'center' },

--- a/tests/tablecellproperties/commands/tablecellhorizontalalignmentcommand.js
+++ b/tests/tablecellproperties/commands/tablecellhorizontalalignmentcommand.js
@@ -143,7 +143,7 @@ describe( 'table cell properties', () => {
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be set if all table cell has the same horizontalAlignment property value', () => {
+					it( 'should be set if all table cells have the same "horizontalAlignment" property value', () => {
 						setData( model, modelTable( [
 							[
 								{ contents: '00', isSelected: true, horizontalAlignment: 'center' },

--- a/tests/tablecellproperties/commands/tablecellhorizontalalignmentcommand.js
+++ b/tests/tablecellproperties/commands/tablecellhorizontalalignmentcommand.js
@@ -230,7 +230,7 @@ describe( 'table cell properties', () => {
 						] ) );
 					} );
 
-					it( 'should set selected table cell horizontalAlignment to a passed value', () => {
+					it( 'should set the "horizontalAlignment" attribute value of selected table cells', () => {
 						command.execute( { value: 'right' } );
 
 						assertEqualMarkup( editor.getData(), viewTable( [

--- a/tests/tablecellproperties/commands/tablecellhorizontalalignmentcommand.js
+++ b/tests/tablecellproperties/commands/tablecellhorizontalalignmentcommand.js
@@ -239,7 +239,7 @@ describe( 'table cell properties', () => {
 						] ) );
 					} );
 
-					it( 'should remove horizontalAlignment from a selected table cell if no value is passed', () => {
+					it( 'should remove the "horizontalAlignment" attribute from selected table cells if no value is passed', () => {
 						setData( model, modelTable( [
 							[ { contents: '00', isSelected: true, horizontalAlignment: 'right' }, '01' ],
 							[ '10', { contents: '11', isSelected: true, horizontalAlignment: 'right' } ]

--- a/tests/tablecellproperties/commands/tablecellhorizontalalignmentcommand.js
+++ b/tests/tablecellproperties/commands/tablecellhorizontalalignmentcommand.js
@@ -128,7 +128,7 @@ describe( 'table cell properties', () => {
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be undefined if one of selected table cells has different horizontalAlignment property value', () => {
+					it( 'should be undefined if one of selected table cells has a different "horizontalAlignment" property value', () => {
 						setData( model, modelTable( [
 							[
 								{ contents: '00', isSelected: true, horizontalAlignment: 'center' },

--- a/tests/tablecellproperties/commands/tablecellpaddingcommand.js
+++ b/tests/tablecellproperties/commands/tablecellpaddingcommand.js
@@ -57,7 +57,7 @@ describe( 'table cell properties', () => {
 				} );
 
 				describe( 'multi-cell selection', () => {
-					it( 'should be true is selection has table cells', () => {
+					it( 'should be true if the selection contains some table cells', () => {
 						setData( model, modelTable( [
 							[ { contents: '00', isSelected: true }, '01' ],
 							[ '10', { contents: '11', isSelected: true } ]

--- a/tests/tablecellproperties/commands/tablecellpaddingcommand.js
+++ b/tests/tablecellproperties/commands/tablecellpaddingcommand.js
@@ -168,7 +168,7 @@ describe( 'table cell properties', () => {
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be set if all table cell has the same padding property value', () => {
+					it( 'should be set if all table cells have the same "padding" property value', () => {
 						setData( model, modelTable( [
 							[
 								{ contents: '00', isSelected: true, padding: '2em' },

--- a/tests/tablecellproperties/commands/tablecellpaddingcommand.js
+++ b/tests/tablecellproperties/commands/tablecellpaddingcommand.js
@@ -138,7 +138,7 @@ describe( 'table cell properties', () => {
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be undefined if only some table cell has a padding property', () => {
+					it( 'should be undefined if only some table cells have the "padding" property', () => {
 						setData( model, modelTable( [
 							[
 								{ contents: '00', isSelected: true, padding: '2em' },

--- a/tests/tablecellproperties/commands/tablecellpaddingcommand.js
+++ b/tests/tablecellproperties/commands/tablecellpaddingcommand.js
@@ -311,7 +311,7 @@ describe( 'table cell properties', () => {
 						] ) );
 					} );
 
-					it( 'should set selected table cell padding to a passed value', () => {
+					it( 'should set the "padding" attribute value of selected table cells', () => {
 						command.execute( { value: '25px' } );
 
 						assertEqualMarkup( editor.getData(), viewTable( [

--- a/tests/tablecellproperties/commands/tablecellpaddingcommand.js
+++ b/tests/tablecellproperties/commands/tablecellpaddingcommand.js
@@ -320,7 +320,7 @@ describe( 'table cell properties', () => {
 						] ) );
 					} );
 
-					it( 'should remove padding from a selected table cell if no value is passed', () => {
+					it( 'should remove "padding" from selected table cells if no value is passed', () => {
 						setData( model, modelTable( [
 							[ { contents: '00', isSelected: true, padding: '25px' }, '01' ],
 							[ '10', { contents: '11', isSelected: true, padding: '25px' } ]

--- a/tests/tablecellproperties/commands/tablecellpaddingcommand.js
+++ b/tests/tablecellproperties/commands/tablecellpaddingcommand.js
@@ -153,7 +153,7 @@ describe( 'table cell properties', () => {
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be undefined if one of selected table cells has different padding property value', () => {
+					it( 'should be undefined if one of selected table cells has a different "padding" property value', () => {
 						setData( model, modelTable( [
 							[
 								{ contents: '00', isSelected: true, padding: '2em' },

--- a/tests/tablecellproperties/commands/tablecellpaddingcommand.js
+++ b/tests/tablecellproperties/commands/tablecellpaddingcommand.js
@@ -123,7 +123,7 @@ describe( 'table cell properties', () => {
 				} );
 
 				describe( 'multi-cell selection', () => {
-					it( 'should be undefined if no table cell has a padding property', () => {
+					it( 'should be undefined if no table cells have the "padding" property', () => {
 						setData( model, modelTable( [
 							[
 								{ contents: '00', isSelected: true },

--- a/tests/tablecellproperties/commands/tablecellverticalalignmentcommand.js
+++ b/tests/tablecellproperties/commands/tablecellverticalalignmentcommand.js
@@ -57,7 +57,7 @@ describe( 'table cell properties', () => {
 				} );
 
 				describe( 'multi-cell selection', () => {
-					it( 'should be true is selection has table cells', () => {
+					it( 'should be true if the selection contains some table cells', () => {
 						setData( model, modelTable( [
 							[ { contents: '00', isSelected: true }, '01' ],
 							[ '10', { contents: '11', isSelected: true } ]

--- a/tests/tablecellproperties/commands/tablecellverticalalignmentcommand.js
+++ b/tests/tablecellproperties/commands/tablecellverticalalignmentcommand.js
@@ -143,7 +143,7 @@ describe( 'table cell properties', () => {
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be set if all table cell has the same verticalAlignment property value', () => {
+					it( 'should be set if all table cells have the same "verticalAlignment" property value', () => {
 						setData( model, modelTable( [
 							[
 								{ contents: '00', isSelected: true, verticalAlignment: 'bottom' },

--- a/tests/tablecellproperties/commands/tablecellverticalalignmentcommand.js
+++ b/tests/tablecellproperties/commands/tablecellverticalalignmentcommand.js
@@ -128,7 +128,7 @@ describe( 'table cell properties', () => {
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be undefined if one of selected table cells has different verticalAlignment property value', () => {
+					it( 'should be undefined if one of selected table cells has a different "verticalAlignment" property value', () => {
 						setData( model, modelTable( [
 							[
 								{ contents: '00', isSelected: true, verticalAlignment: 'bottom' },

--- a/tests/tablecellproperties/commands/tablecellverticalalignmentcommand.js
+++ b/tests/tablecellproperties/commands/tablecellverticalalignmentcommand.js
@@ -98,7 +98,7 @@ describe( 'table cell properties', () => {
 				} );
 
 				describe( 'multi-cell selection', () => {
-					it( 'should be undefined if no table cell has a verticalAlignment property', () => {
+					it( 'should be undefined if no table cells have the "verticalAlignment" property', () => {
 						setData( model, modelTable( [
 							[
 								{ contents: '00', isSelected: true },

--- a/tests/tablecellproperties/commands/tablecellverticalalignmentcommand.js
+++ b/tests/tablecellproperties/commands/tablecellverticalalignmentcommand.js
@@ -230,7 +230,7 @@ describe( 'table cell properties', () => {
 						] ) );
 					} );
 
-					it( 'should set selected table cell verticalAlignment to a passed value', () => {
+					it( 'should set the "verticalAlignment" attribute value of selected table cells', () => {
 						command.execute( { value: 'top' } );
 
 						assertEqualMarkup( editor.getData(), viewTable( [

--- a/tests/tablecellproperties/commands/tablecellverticalalignmentcommand.js
+++ b/tests/tablecellproperties/commands/tablecellverticalalignmentcommand.js
@@ -239,7 +239,7 @@ describe( 'table cell properties', () => {
 						] ) );
 					} );
 
-					it( 'should remove verticalAlignment from a selected table cell if no value is passed', () => {
+					it( 'should remove "verticalAlignment" from selected table cells if no value is passed', () => {
 						setData( model, modelTable( [
 							[ { contents: '00', isSelected: true, verticalAlignment: 'top' }, '01' ],
 							[ '10', { contents: '11', isSelected: true, verticalAlignment: 'top' } ]

--- a/tests/tablecellproperties/commands/tablecellverticalalignmentcommand.js
+++ b/tests/tablecellproperties/commands/tablecellverticalalignmentcommand.js
@@ -113,7 +113,7 @@ describe( 'table cell properties', () => {
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be undefined if only some table cell has a verticalAlignment property', () => {
+					it( 'should be undefined if only some table cells have the "verticalAlignment" property', () => {
 						setData( model, modelTable( [
 							[
 								{ contents: '00', isSelected: true, verticalAlignment: 'bottom' },

--- a/tests/tablecellproperties/commands/tablecellwidthcommand.js
+++ b/tests/tablecellproperties/commands/tablecellwidthcommand.js
@@ -57,7 +57,7 @@ describe( 'table cell properties', () => {
 				} );
 
 				describe( 'multi-cell selection', () => {
-					it( 'should be true is selection has table cells', () => {
+					it( 'should be true if the selection contains some table cells', () => {
 						setData( model, modelTable( [
 							[ { contents: '00', isSelected: true }, '01' ],
 							[ '10', { contents: '11', isSelected: true } ]

--- a/tests/tablecellproperties/commands/tablecellwidthcommand.js
+++ b/tests/tablecellproperties/commands/tablecellwidthcommand.js
@@ -128,7 +128,7 @@ describe( 'table cell properties', () => {
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be undefined if one of selected table cells has different width property value', () => {
+					it( 'should be undefined if one of selected table cells has a different "width" property value', () => {
 						setData( model, modelTable( [
 							[
 								{ contents: '00', isSelected: true, width: '100px' },

--- a/tests/tablecellproperties/commands/tablecellwidthcommand.js
+++ b/tests/tablecellproperties/commands/tablecellwidthcommand.js
@@ -286,7 +286,7 @@ describe( 'table cell properties', () => {
 						] ) );
 					} );
 
-					it( 'should set selected table cell width to a passed value', () => {
+					it( 'should set the "width" attribute value of selected table cells', () => {
 						command.execute( { value: '25px' } );
 
 						assertEqualMarkup( editor.getData(), viewTable( [

--- a/tests/tablecellproperties/commands/tablecellwidthcommand.js
+++ b/tests/tablecellproperties/commands/tablecellwidthcommand.js
@@ -295,7 +295,7 @@ describe( 'table cell properties', () => {
 						] ) );
 					} );
 
-					it( 'should remove width from a selected table cell if no value is passed', () => {
+					it( 'should remove "width" from selected table cells if no value is passed', () => {
 						setData( model, modelTable( [
 							[ { contents: '00', isSelected: true, width: '25px' }, '01' ],
 							[ '10', { contents: '11', isSelected: true, width: '25px' } ]

--- a/tests/tablecellproperties/commands/tablecellwidthcommand.js
+++ b/tests/tablecellproperties/commands/tablecellwidthcommand.js
@@ -113,7 +113,7 @@ describe( 'table cell properties', () => {
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be undefined if only some table cell has a width property', () => {
+					it( 'should be undefined if only some table cells have the "width" property', () => {
 						setData( model, modelTable( [
 							[
 								{ contents: '00', isSelected: true, width: '100px' },

--- a/tests/tablecellproperties/commands/tablecellwidthcommand.js
+++ b/tests/tablecellproperties/commands/tablecellwidthcommand.js
@@ -98,7 +98,7 @@ describe( 'table cell properties', () => {
 				} );
 
 				describe( 'multi-cell selection', () => {
-					it( 'should be undefined if no table cell has a width property', () => {
+					it( 'should be undefined if no table cells have the "width" property', () => {
 						setData( model, modelTable( [
 							[
 								{ contents: '00', isSelected: true },

--- a/tests/tablecellproperties/commands/tablecellwidthcommand.js
+++ b/tests/tablecellproperties/commands/tablecellwidthcommand.js
@@ -143,7 +143,7 @@ describe( 'table cell properties', () => {
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be set if all table cell has the same width property value', () => {
+					it( 'should be set if all table cells have the same "width" property value', () => {
 						setData( model, modelTable( [
 							[
 								{ contents: '00', isSelected: true, width: '100px' },


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Enhancement: Add multi-cell selection to table cell properties UI. Closes ckeditor/ckeditor5#6150.

---

### Additional information

This PR adds the ability to style selected table cells with basic logic for command value. I've extracted a follow for for multi-cell values handling as it looks optional and requires decisions.

@Reinmar: is this follow up OK? https://github.com/ckeditor/ckeditor5/issues/6320

