### PR TITLE
I/6119: Clear table contents on clipboard "cut" and keyboard delete

### DIFF
--- a/src/tableclipboard.js
+++ b/src/tableclipboard.js
@@ -10,8 +10,6 @@
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import TableSelection from './tableselection';
 import { clearTableCellsContents } from './tableselection/utils';
-import viewToPlainText from '@ckeditor/ckeditor5-clipboard/src/utils/viewtoplaintext';
-import HtmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/htmldataprocessor';
 
 /**
  * The table clipboard integration plugin.
@@ -98,25 +96,5 @@ export default class TableClipboard extends Plugin {
 			content,
 			method: evt.name
 		} );
-	}
-
-	/**
-	 * Overrides default Clipboard plugin "clipboardOutput" handler to properly handle clearing selected table contents.
-	 *
-	 * @param {module:utils/eventinfo~EventInfo} evt An object containing information about the handled event.
-	 * @param {Object} data Clipboard event data.
-	 * @private
-	 */
-	_onClipboardOutput( evt, data ) {
-		if ( !this._tableSelection.hasMultiCellSelection && data.method !== 'cut' ) {
-			return;
-		}
-
-		evt.stop();
-
-		data.dataTransfer.setData( 'text/html', new HtmlDataProcessor().toData( data.content ) );
-		data.dataTransfer.setData( 'text/plain', viewToPlainText( data.content ) );
-
-		clearTableCellsContents( this.editor.model, this._tableSelection.getSelectedTableCells() );
 	}
 }

--- a/src/tableclipboard.js
+++ b/src/tableclipboard.js
@@ -9,6 +9,7 @@
 
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import TableSelection from './tableselection';
+import { clearTableCellsContents } from './tableselection/utils';
 
 /**
  * The table clipboard integration plugin.
@@ -92,6 +93,8 @@ export default class TableClipboard extends Plugin {
 		if ( this._tableSelection.hasMultiCellSelection ) {
 			data.preventDefault();
 			evt.stop();
+
+			clearTableCellsContents( this.editor.model, this._tableSelection.getSelectedTableCells() );
 		}
 	}
 }

--- a/src/tableclipboard.js
+++ b/src/tableclipboard.js
@@ -58,10 +58,15 @@ export default class TableClipboard extends Plugin {
 
 		this.listenTo( editor.model, 'deleteContent', ( evt, args ) => {
 			const [ selection ] = args;
+
 			if ( this._tableSelection.hasMultiCellSelection && selection.is( 'documentSelection' ) ) {
 				evt.stop();
 
 				clearTableCellsContents( this.editor.model, this._tableSelection.getSelectedTableCells() );
+
+				editor.model.change( writer => {
+					writer.setSelection( Array.from( this._tableSelection.getSelectedTableCells() ).pop(), 0 );
+				} );
 			}
 		}, { priority: 'high' } );
 	}

--- a/src/tableclipboard.js
+++ b/src/tableclipboard.js
@@ -53,7 +53,17 @@ export default class TableClipboard extends Plugin {
 
 		this.listenTo( viewDocument, 'copy', ( evt, data ) => this._onCopyCut( evt, data ) );
 		this.listenTo( viewDocument, 'cut', ( evt, data ) => this._onCopyCut( evt, data ) );
-		this.listenTo( viewDocument, 'clipboardOutput', ( evt, data ) => this._onClipboardOutput( evt, data ) );
+
+		// TODO: move to table selection plugin as it looks like a general problem solver.
+
+		this.listenTo( editor.model, 'deleteContent', ( evt, args ) => {
+			const [ selection ] = args;
+			if ( this._tableSelection.hasMultiCellSelection && selection.is( 'documentSelection' ) ) {
+				evt.stop();
+
+				clearTableCellsContents( this.editor.model, this._tableSelection.getSelectedTableCells() );
+			}
+		}, { priority: 'high' } );
 	}
 
 	/**

--- a/src/tableclipboard.js
+++ b/src/tableclipboard.js
@@ -9,7 +9,6 @@
 
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import TableSelection from './tableselection';
-import { clearTableCellsContents } from './tableselection/utils';
 
 /**
  * The table clipboard integration plugin.
@@ -51,22 +50,6 @@ export default class TableClipboard extends Plugin {
 
 		this.listenTo( viewDocument, 'copy', ( evt, data ) => this._onCopyCut( evt, data ) );
 		this.listenTo( viewDocument, 'cut', ( evt, data ) => this._onCopyCut( evt, data ) );
-
-		// TODO: move to table selection plugin as it looks like a general problem solver.
-
-		this.listenTo( editor.model, 'deleteContent', ( evt, args ) => {
-			const [ selection ] = args;
-
-			if ( this._tableSelection.hasMultiCellSelection && selection.is( 'documentSelection' ) ) {
-				evt.stop();
-
-				clearTableCellsContents( this.editor.model, this._tableSelection.getSelectedTableCells() );
-
-				editor.model.change( writer => {
-					writer.setSelection( Array.from( this._tableSelection.getSelectedTableCells() ).pop(), 0 );
-				} );
-			}
-		}, { priority: 'high' } );
 	}
 
 	/**

--- a/src/tableselection.js
+++ b/src/tableselection.js
@@ -14,6 +14,7 @@ import TableUtils from './tableutils';
 import { setupTableSelectionHighlighting } from './tableselection/converters';
 import MouseSelectionHandler from './tableselection/mouseselectionhandler';
 import { findAncestor } from './commands/utils';
+import { clearTableCellsContents } from './tableselection/utils';
 import cropTable from './tableselection/croptable';
 
 import '../theme/tableselection.css';
@@ -107,7 +108,7 @@ export default class TableSelection extends Plugin {
 			if ( this.hasMultiCellSelection ) {
 				evt.stop();
 
-				this.clearSelectedTableCells();
+				clearTableCellsContents( editor.model, this.getSelectedTableCells() );
 			}
 		}, { priority: 'high' } );
 	}
@@ -248,17 +249,6 @@ export default class TableSelection extends Plugin {
 			writer.insert( table, documentFragment, 0 );
 
 			return documentFragment;
-		} );
-	}
-
-	// TODO: helper function?
-	clearSelectedTableCells() {
-		const model = this.editor.model;
-
-		model.change( writer => {
-			for ( const tableCell of this.getSelectedTableCells() ) {
-				model.deleteContent( writer.createSelection( tableCell, 'in' ) );
-			}
 		} );
 	}
 

--- a/src/tableselection.js
+++ b/src/tableselection.js
@@ -108,7 +108,22 @@ export default class TableSelection extends Plugin {
 			if ( this.hasMultiCellSelection ) {
 				evt.stop();
 
+				// TODO: why not deleteContent decorator???
 				clearTableCellsContents( editor.model, this.getSelectedTableCells() );
+			}
+		}, { priority: 'high' } );
+
+		this.listenTo( editor.model, 'deleteContent', ( evt, args ) => {
+			const [ selection ] = args;
+
+			if ( this.hasMultiCellSelection && selection.is( 'documentSelection' ) ) {
+				evt.stop();
+
+				clearTableCellsContents( this.editor.model, this.getSelectedTableCells() );
+
+				editor.model.change( writer => {
+					writer.setSelection( Array.from( this.getSelectedTableCells() ).pop(), 0 );
+				} );
 			}
 		}, { priority: 'high' } );
 	}

--- a/src/tableselection.js
+++ b/src/tableselection.js
@@ -102,6 +102,14 @@ export default class TableSelection extends Plugin {
 		setupTableSelectionHighlighting( editor, this );
 
 		selection.on( 'change:range', () => this._clearSelectionOnExternalChange( selection ) );
+
+		this.listenTo( editor.editing.view.document, 'delete', evt => {
+			if ( this.hasMultiCellSelection ) {
+				evt.stop();
+
+				this.clearSelectedTableCells();
+			}
+		}, { priority: 'high' } );
 	}
 
 	/**
@@ -240,6 +248,17 @@ export default class TableSelection extends Plugin {
 			writer.insert( table, documentFragment, 0 );
 
 			return documentFragment;
+		} );
+	}
+
+	// TODO: helper function?
+	clearSelectedTableCells() {
+		const model = this.editor.model;
+
+		model.change( writer => {
+			for ( const tableCell of this.getSelectedTableCells() ) {
+				model.deleteContent( writer.createSelection( tableCell, 'in' ) );
+			}
 		} );
 	}
 

--- a/src/tableselection.js
+++ b/src/tableselection.js
@@ -96,14 +96,14 @@ export default class TableSelection extends Plugin {
 	init() {
 		const editor = this.editor;
 		const selection = editor.model.document.selection;
+		const viewDoc = editor.editing.view.document;
 
 		this._tableUtils = editor.plugins.get( 'TableUtils' );
 
 		setupTableSelectionHighlighting( editor, this );
 
-		selection.on( 'change:range', () => this._clearSelectionOnExternalChange( selection ) );
-
-		this.listenTo( editor.editing.view.document, 'delete', evt => {
+		this.listenTo( selection, 'change:range', () => this._clearSelectionOnExternalChange( selection ) );
+		this.listenTo( viewDoc, 'delete', evt => {
 			if ( this.hasMultiCellSelection ) {
 				evt.stop();
 

--- a/src/tableselection.js
+++ b/src/tableselection.js
@@ -114,14 +114,20 @@ export default class TableSelection extends Plugin {
 		const editor = this.editor;
 
 		const deleteCommand = editor.commands.get( 'delete' );
+
+		if ( deleteCommand ) {
+			this.listenTo( deleteCommand, 'execute', event => {
+				this._handleDeleteCommand( event, { isForward: false } );
+			}, { priority: 'high' } );
+		}
+
 		const forwardDeleteCommand = editor.commands.get( 'forwardDelete' );
 
-		this.listenTo( deleteCommand, 'execute', event => {
-			this._handleDeleteCommand( event, { isForward: false } );
-		}, { priority: 'high' } );
-		this.listenTo( forwardDeleteCommand, 'execute', event => {
-			this._handleDeleteCommand( event, { isForward: true } );
-		}, { priority: 'high' } );
+		if ( forwardDeleteCommand ) {
+			this.listenTo( forwardDeleteCommand, 'execute', event => {
+				this._handleDeleteCommand( event, { isForward: true } );
+			}, { priority: 'high' } );
+		}
 	}
 
 	/**

--- a/src/tableselection/croptable.js
+++ b/src/tableselection/croptable.js
@@ -17,7 +17,7 @@ import { findAncestor } from '../commands/utils';
  *		tableSelection.startSelectingFrom( startCell )
  *		tableSelection.setSelectingFrom( endCell )
  *
- *		const croppedTable = cropTable( tableSelection.getSelectedTableCells );
+ *		const croppedTable = cropTable( tableSelection.getSelectedTableCells() );
  *
  * **Note**: This function is used also by {@link module:table/tableselection~TableSelection#getSelectionAsFragment}
  *

--- a/src/tableselection/utils.js
+++ b/src/tableselection/utils.js
@@ -1,0 +1,31 @@
+/**
+ * @license Copyright (c) 2003-2020, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/**
+ * @module table/tableselection/utils
+ */
+
+/**
+ * Clears contents of the passed table cells.
+ *
+ * This is to be used with table selection
+ *
+ *		tableSelection.startSelectingFrom( startCell )
+ *		tableSelection.setSelectingFrom( endCell )
+ *
+ *		clearTableCellsContents( editor.model, tableSelection.getSelectedTableCells() );
+ *
+ * **Note**: This function is used also by {@link module:table/tableselection~TableSelection#getSelectionAsFragment}
+ *
+ * @param {module:engine/model/model~Model} model
+ * @param {Iterable.<module:engine/model/element~Element>} tableCells
+ */
+export function clearTableCellsContents( model, tableCells ) {
+	model.change( writer => {
+		for ( const tableCell of tableCells ) {
+			model.deleteContent( writer.createSelection( tableCell, 'in' ) );
+		}
+	} );
+}

--- a/tests/tableclipboard.js
+++ b/tests/tableclipboard.js
@@ -13,7 +13,7 @@ import Clipboard from '@ckeditor/ckeditor5-clipboard/src/clipboard';
 import TableClipboard from '../src/tableclipboard';
 import { assertEqualMarkup } from '@ckeditor/ckeditor5-utils/tests/_utils/utils';
 
-describe.only( 'table clipboard', () => {
+describe( 'table clipboard', () => {
 	let editor, model, modelRoot, tableSelection, viewDocument;
 
 	beforeEach( async () => {
@@ -278,9 +278,25 @@ describe.only( 'table clipboard', () => {
 				expect( dataTransferMock.getData( 'text/html' ) ).to.equal( '00' );
 			} );
 
+			it( 'should be preventable', () => {
+				tableSelection.startSelectingFrom( modelRoot.getNodeByPath( [ 0, 0, 0 ] ) );
+				tableSelection.setSelectingTo( modelRoot.getNodeByPath( [ 0, 1, 1 ] ) );
+
+				viewDocument.on( 'clipboardOutput', evt => evt.stop(), { priority: 'high' } );
+
+				viewDocument.fire( 'cut', {
+					dataTransfer: createDataTransfer(),
+					preventDefault: sinon.spy()
+				} );
+
+				assertEqualMarkup( getModelData( model ), modelTable( [
+					[ { contents: '00', isSelected: true }, { contents: '01', isSelected: true }, '02' ],
+					[ { contents: '10', isSelected: true }, { contents: '11', isSelected: true }, '12' ],
+					[ '20', '21', '22' ]
+				] ) );
+			} );
+
 			it( 'is clears selected table cells', () => {
-				const dataTransferMock = createDataTransfer();
-				const preventDefaultSpy = sinon.spy();
 				const spy = sinon.spy();
 
 				viewDocument.on( 'clipboardOutput', spy );
@@ -289,8 +305,8 @@ describe.only( 'table clipboard', () => {
 				tableSelection.setSelectingTo( modelRoot.getNodeByPath( [ 0, 1, 1 ] ) );
 
 				viewDocument.fire( 'cut', {
-					dataTransfer: dataTransferMock,
-					preventDefault: preventDefaultSpy
+					dataTransfer: createDataTransfer(),
+					preventDefault: sinon.spy()
 				} );
 
 				assertEqualMarkup( getModelData( model ), modelTable( [

--- a/tests/tableclipboard.js
+++ b/tests/tableclipboard.js
@@ -13,7 +13,7 @@ import Clipboard from '@ckeditor/ckeditor5-clipboard/src/clipboard';
 import TableClipboard from '../src/tableclipboard';
 import { assertEqualMarkup } from '@ckeditor/ckeditor5-utils/tests/_utils/utils';
 
-describe( 'table clipboard', () => {
+describe.only( 'table clipboard', () => {
 	let editor, model, modelRoot, tableSelection, viewDocument;
 
 	beforeEach( async () => {
@@ -39,7 +39,7 @@ describe( 'table clipboard', () => {
 
 	describe( 'Clipboard integration', () => {
 		describe( 'copy', () => {
-			it( 'should to nothing for normal selection in table', () => {
+			it( 'should do nothing for normal selection in table', () => {
 				const dataTransferMock = createDataTransfer();
 				const spy = sinon.spy();
 
@@ -261,18 +261,21 @@ describe( 'table clipboard', () => {
 		} );
 
 		describe( 'cut', () => {
-			it( 'is not disabled normal selection over a table', () => {
-				const dataTransferMock = createDataTransfer();
-				const spy = sinon.spy();
+			it( 'should not block clipboardOutput if no multi-cell selection', () => {
+				setModelData( model, modelTable( [
+					[ '[00]', '01', '02' ],
+					[ '10', '11', '12' ],
+					[ '20', '21', '22' ]
+				] ) );
 
-				viewDocument.on( 'clipboardOutput', spy );
+				const dataTransferMock = createDataTransfer();
 
 				viewDocument.fire( 'cut', {
 					dataTransfer: dataTransferMock,
 					preventDefault: sinon.spy()
 				} );
 
-				sinon.assert.calledOnce( spy );
+				expect( dataTransferMock.getData( 'text/html' ) ).to.equal( '00' );
 			} );
 
 			it( 'is clears selected table cells', () => {

--- a/tests/tableclipboard.js
+++ b/tests/tableclipboard.js
@@ -310,8 +310,8 @@ describe( 'table clipboard', () => {
 				} );
 
 				assertEqualMarkup( getModelData( model ), modelTable( [
-					[ { contents: '', isSelected: true }, { contents: '', isSelected: true }, '02' ],
-					[ { contents: '', isSelected: true }, { contents: '', isSelected: true }, '12' ],
+					[ '', '', '02' ],
+					[ '', '[]', '12' ],
 					[ '20', '21', '22' ]
 				] ) );
 			} );

--- a/tests/tableselection-integration.js
+++ b/tests/tableselection-integration.js
@@ -30,7 +30,7 @@ describe( 'table selection', () => {
 				await setupEditor( [ Delete ] );
 			} );
 
-			it( 'should clear contents of the selected table cells', () => {
+			it( 'should clear contents of the selected table cells and put selection in last cell on backward delete', () => {
 				tableSelection.startSelectingFrom( modelRoot.getNodeByPath( [ 0, 0, 0 ] ) );
 				tableSelection.setSelectingTo( modelRoot.getNodeByPath( [ 0, 1, 1 ] ) );
 
@@ -44,8 +44,28 @@ describe( 'table selection', () => {
 				editor.editing.view.document.fire( 'delete', domEventData );
 
 				assertEqualMarkup( getModelData( model ), modelTable( [
-					[ { contents: '', isSelected: true }, { contents: '', isSelected: true }, '13' ],
-					[ { contents: '', isSelected: true }, { contents: '', isSelected: true }, '23' ],
+					[ '', '', '13' ],
+					[ '', '[]', '23' ],
+					[ '31', '32', '33' ]
+				] ) );
+			} );
+
+			it( 'should clear contents of the selected table cells and put selection in last cell on forward delete', () => {
+				tableSelection.startSelectingFrom( modelRoot.getNodeByPath( [ 0, 0, 0 ] ) );
+				tableSelection.setSelectingTo( modelRoot.getNodeByPath( [ 0, 1, 1 ] ) );
+
+				const domEventData = new DomEventData( editor.editing.view.document, {
+					preventDefault: sinon.spy()
+				}, {
+					direction: 'forward',
+					unit: 'character',
+					sequence: 1
+				} );
+				editor.editing.view.document.fire( 'delete', domEventData );
+
+				assertEqualMarkup( getModelData( model ), modelTable( [
+					[ '[]', '', '13' ],
+					[ '', '', '23' ],
 					[ '31', '32', '33' ]
 				] ) );
 			} );

--- a/tests/tableselection-integration.js
+++ b/tests/tableselection-integration.js
@@ -1,0 +1,90 @@
+/**
+ * @license Copyright (c) 2003-2020, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* globals document */
+
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+import { getData as getModelData, setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
+
+import TableEditing from '../src/tableediting';
+import TableSelection from '../src/tableselection';
+import { modelTable } from './_utils/utils';
+import { assertEqualMarkup } from '@ckeditor/ckeditor5-utils/tests/_utils/utils';
+import DomEventData from '@ckeditor/ckeditor5-engine/src/view/observer/domeventdata';
+import Delete from '@ckeditor/ckeditor5-typing/src/delete';
+import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
+
+describe( 'table selection', () => {
+	let editor, model, tableSelection, modelRoot, element;
+
+	describe( 'TableSelection - input integration', () => {
+		afterEach( async () => {
+			element.remove();
+			await editor.destroy();
+		} );
+
+		describe( 'on delete', () => {
+			beforeEach( async () => {
+				await setupEditor( [ Delete ] );
+			} );
+
+			it( 'should clear contents of the selected table cells', () => {
+				tableSelection.startSelectingFrom( modelRoot.getNodeByPath( [ 0, 0, 0 ] ) );
+				tableSelection.setSelectingTo( modelRoot.getNodeByPath( [ 0, 1, 1 ] ) );
+
+				const domEventData = new DomEventData( editor.editing.view.document, {
+					preventDefault: sinon.spy()
+				}, {
+					direction: 'backward',
+					unit: 'character',
+					sequence: 1
+				} );
+				editor.editing.view.document.fire( 'delete', domEventData );
+
+				assertEqualMarkup( getModelData( model ), modelTable( [
+					[ { contents: '', isSelected: true }, { contents: '', isSelected: true }, '13' ],
+					[ { contents: '', isSelected: true }, { contents: '', isSelected: true }, '23' ],
+					[ '31', '32', '33' ]
+				] ) );
+			} );
+
+			it( 'should not interfere with default key handler if no table selection', () => {
+				const domEventData = new DomEventData( editor.editing.view.document, {
+					preventDefault: sinon.spy()
+				}, {
+					direction: 'backward',
+					unit: 'character',
+					sequence: 1
+				} );
+				editor.editing.view.document.fire( 'delete', domEventData );
+
+				assertEqualMarkup( getModelData( model ), modelTable( [
+					[ '1[]', '12', '13' ],
+					[ '21', '22', '23' ],
+					[ '31', '32', '33' ]
+				] ) );
+			} );
+		} );
+	} );
+
+	async function setupEditor( plugins ) {
+		element = document.createElement( 'div' );
+		document.body.appendChild( element );
+
+		editor = await ClassicTestEditor.create( element, {
+			plugins: [ TableEditing, TableSelection, Paragraph, ...plugins ]
+		} );
+
+		model = editor.model;
+		modelRoot = model.document.getRoot();
+		tableSelection = editor.plugins.get( TableSelection );
+
+		setModelData( model, modelTable( [
+			[ '11[]', '12', '13' ],
+			[ '21', '22', '23' ],
+			[ '31', '32', '33' ]
+		] ) );
+	}
+} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Clear table contents on clipboard "cut" and keyboard delete. Closes ckeditor/ckeditor5#6119. Closes ckeditor/ckeditor5#6284. Closes ckeditor/ckeditor5#6301.

---

### Additional information

For the "cut" event handler I had to override (thus duplicate) default `Clipboard` plugin behavior which was removing a single range instead of multi-range selection. This could be simplified by enhancing `model.deleteContent()` (reported here: https://github.com/ckeditor/ckeditor5/issues/6328).

