### PR TITLE
I/6346: TableSelection should work with external changes.

### DIFF
--- a/src/tableselection.js
+++ b/src/tableselection.js
@@ -72,6 +72,23 @@ export default class TableSelection extends Plugin {
 		 * @member {module:table/tableselection/mouseselectionhandler~MouseSelectionHandler}
 		 */
 		this._mouseHandler = new MouseSelectionHandler( this, this.editor.editing );
+		const model = editor.model;
+		const selection = model.document.selection;
+
+		editor.model.document.selection.on( 'change', () => {
+			const tableCells = Array.from( selection.getSelectedBlocks() )
+				.map( element => findAncestor( 'tableCell', model.createPositionAt( element, 0 ) ) )
+				.filter( tableCell => !!tableCell );
+
+			const size = tableCells.length;
+
+			if ( !this.hasMultiCellSelection && size ) {
+				// this is undo or external change to the selection so "fix" internal state.
+
+				this._startElement = tableCells[ 0 ];
+				this._endElement = tableCells[ tableCells.length - 1 ];
+			}
+		}, { priority: 'highest' } );
 
 		/**
 		 * A reference to the table utilities used across the class.

--- a/tests/tableselection-integration.js
+++ b/tests/tableselection-integration.js
@@ -160,20 +160,25 @@ describe( 'table selection', () => {
 
 		describe( 'on undo', () => {
 			beforeEach( async () => {
-				await setupEditor( [ UndoEditing ] );
+				await setupEditor( [ Input, UndoEditing ] );
 			} );
 
 			it( 'should clear contents of the selected table cells and put selection in last cell on backward delete', () => {
 				tableSelection.startSelectingFrom( modelRoot.getNodeByPath( [ 0, 0, 0 ] ) );
 				tableSelection.setSelectingTo( modelRoot.getNodeByPath( [ 0, 1, 1 ] ) );
 
-				model.change( writer => {
-					writer.setSelection( modelRoot.getNodeByPath( [ 0, 0, 0, 0 ] ), 0 );
-					model.insertContent( writer.createText( 'foobar' ) );
+				const node = modelRoot.getNodeByPath( [ 0, 0, 0, 0 ] );
+				editor.execute( 'input', {
+					text: 'foobar',
+					range: model.createRangeIn( modelRoot.getNodeByPath( [ 0, 0, 0, 0 ] ) ),
+					resultRange: model.createRange(
+						model.createPositionAt( node, 0 ),
+						model.createPositionAt( node, 0 )
+					)
 				} );
 
-				assertEqualMarkup( getModelData( model ), modelTable( [
-					[ 'foobar[]11', '12', '13' ],
+				assertEqualMarkup( getModelData( model, { withoutSelection: true } ), modelTable( [
+					[ 'foobar', '12', '13' ],
 					[ '21', '22', '23' ],
 					[ '31', '32', '33' ]
 				] ) );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Type: Message. Closes ckeditor/ckeditor5#6346.

---

### Additional information

* Work in progress - based on https://github.com/ckeditor/ckeditor5-table/pull/254 & https://github.com/ckeditor/ckeditor5-table/pull/253 PRs so it would need to be rebased once those two got merged.

* First naive implmeentation is to "fix" TableSelection state when there's an external change detected (focused on undo case). In such state, there will be some table cells in the selection but internally it will be blank.

* However this is somewhat in a contrary to `_clearSelectionOnExternalChange()` method.
