### PR TITLE
i/6114: Improved the look of multi-cell selection. Prevented the selection from starting in the fake selection container

### DIFF
--- a/src/tablecellproperties/commands/tablecellpropertycommand.js
+++ b/src/tablecellproperties/commands/tablecellpropertycommand.js
@@ -97,7 +97,8 @@ export default class TableCellPropertyCommand extends Command {
 	}
 
 	/**
-	 * Returns a single value for all selected table cells. If the value is the same for all cells, it will be returned (`undefined` otherwise).
+	 * Returns a single value for all selected table cells. If the value is the same for all cells,
+	 * it will be returned (`undefined` otherwise).
 	 *
 	 * @param {Array.<module:engine/model/element~Element>} tableCell
 	 * @returns {*}

--- a/src/tableselection/mouseselectionhandler.js
+++ b/src/tableselection/mouseselectionhandler.js
@@ -95,7 +95,7 @@ export default class MouseSelectionHandler {
 	 * @private
 	 */
 	_handleMouseMove( domEventData ) {
-		if ( !isButtonPressed( domEventData ) ) {
+		if ( !this._isSelecting || !isButtonPressed( domEventData ) ) {
 			this._tableSelection.stopSelection();
 
 			return;

--- a/src/tableselection/mouseselectionhandler.js
+++ b/src/tableselection/mouseselectionhandler.js
@@ -40,10 +40,11 @@ export default class MouseSelectionHandler {
 		 * A flag indicating that the mouse selection is "active". A selection is "active" if it was started and not yet finished.
 		 * A selection can be "active", for instance, if a user moves a mouse over a table while holding a mouse button down.
 		 *
+		 * @private
 		 * @readonly
 		 * @member {Boolean}
 		 */
-		this.isSelecting = false;
+		this._isSelecting = false;
 
 		/**
 		 * Editing mapper.
@@ -77,12 +78,11 @@ export default class MouseSelectionHandler {
 
 		if ( !tableCell ) {
 			this._tableSelection.clearSelection();
-			this._tableSelection.stopSelection();
 
 			return;
 		}
 
-		this.isSelecting = true;
+		this._isSelecting = true;
 		this._tableSelection.startSelectingFrom( tableCell );
 	}
 
@@ -119,9 +119,11 @@ export default class MouseSelectionHandler {
 	 * @private
 	 */
 	_handleMouseUp( domEventData ) {
-		if ( !this.isSelecting ) {
+		if ( !this._isSelecting ) {
 			return;
 		}
+
+		this._isSelecting = false;
 
 		const tableCell = this._getModelTableCellFromDomEvent( domEventData );
 

--- a/src/tableselection/mouseselectionhandler.js
+++ b/src/tableselection/mouseselectionhandler.js
@@ -101,6 +101,9 @@ export default class MouseSelectionHandler {
 			return;
 		}
 
+		// https://github.com/ckeditor/ckeditor5/issues/6114
+		domEventData.preventDefault();
+
 		const tableCell = this._getModelTableCellFromDomEvent( domEventData );
 
 		if ( !tableCell ) {

--- a/tests/manual/tableselection.html
+++ b/tests/manual/tableselection.html
@@ -12,6 +12,11 @@
 	.external-source td, .external-source th {
 		border: solid 1px hsl(0, 0%, 85%);
 	}
+
+	/* It should not create entire viewport scroll. */
+	pre {
+		overflow: auto;
+	}
 </style>
 
 <h3>A "content" test editor</h3>

--- a/tests/manual/tableselection.html
+++ b/tests/manual/tableselection.html
@@ -52,7 +52,13 @@
 					<td>k</td>
 					<td>l</td>
 					<td><strong>m</strong></td>
-					<td>n</td>
+					<td>
+						<p>n</p>
+						<figure class="image image-style-side">
+							<img src="sample.jpg" />
+							<figcaption>Caption!</figcaption>
+						</figure>
+					</td>
 					<td>o</td>
 				</tr>
 				<tr>

--- a/tests/manual/tableselection.js
+++ b/tests/manual/tableselection.js
@@ -31,6 +31,9 @@ function createEditor( target, inspectorName ) {
 				'bulletedList', 'numberedList', 'blockQuote', '|',
 				'undo', 'redo'
 			],
+			image: {
+				toolbar: [ 'imageStyle:full', 'imageStyle:side', '|', 'imageTextAlternative' ]
+			},
 			table: {
 				contentToolbar: [ 'tableColumn', 'tableRow', 'mergeTableCells', 'tableProperties', 'tableCellProperties' ]
 			}

--- a/tests/tableselection/mouseselectionhandler.js
+++ b/tests/tableselection/mouseselectionhandler.js
@@ -12,9 +12,12 @@ import { assertEqualMarkup } from '@ckeditor/ckeditor5-utils/tests/_utils/utils'
 import TableEditing from '../../src/tableediting';
 import TableSelection from '../../src/tableselection';
 import { assertSelectedCells, modelTable, viewTable } from '../_utils/utils';
+import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 
 describe( 'table selection', () => {
 	let editor, model, view, viewDoc;
+
+	testUtils.createSinonSandbox();
 
 	beforeEach( async () => {
 		editor = await VirtualTestEditor.create( {
@@ -417,6 +420,27 @@ describe( 'table selection', () => {
 				[ '00', '01' ],
 				[ '10', '11' ]
 			], { asWidget: true } ) + '<p>{}foo</p>' );
+		} );
+
+		// https://github.com/ckeditor/ckeditor5/issues/6353
+		it( 'should do nothing on successive "mouseup" events beyond the table after the selection was fininished', () => {
+			const spy = testUtils.sinon.spy( editor.plugins.get( 'TableSelection' ), 'stopSelection' );
+
+			setModelData( model, modelTable( [
+				[ '[]00', '01' ],
+				[ '10', '11' ]
+			] ) );
+
+			pressMouseButtonOver( getTableCell( '00' ) );
+			movePressedMouseOver( getTableCell( '11' ) );
+			releaseMouseButtonOver( getTableCell( '11' ) );
+
+			sinon.assert.calledOnce( spy );
+
+			pressMouseButtonOver( viewDoc.getRoot() );
+			releaseMouseButtonOver( viewDoc.getRoot() );
+
+			sinon.assert.calledOnce( spy );
 		} );
 	} );
 

--- a/tests/tableselection/mouseselectionhandler.js
+++ b/tests/tableselection/mouseselectionhandler.js
@@ -442,6 +442,20 @@ describe( 'table selection', () => {
 
 			sinon.assert.calledOnce( spy );
 		} );
+
+		// https://github.com/ckeditor/ckeditor5/issues/6114
+		it( 'should prevent default the "mousemove" event to prevent the native DOM selection from changing', () => {
+			setModelData( model, modelTable( [
+				[ '[]00', '01' ],
+				[ '10', '11' ]
+			] ) );
+
+			pressMouseButtonOver( getTableCell( '00' ) );
+			const domEvtData = movePressedMouseOver( getTableCell( '11' ) );
+			releaseMouseButtonOver( getTableCell( '11' ) );
+
+			sinon.assert.calledOnce( domEvtData.preventDefault );
+		} );
 	} );
 
 	function getTableCell( data ) {
@@ -461,7 +475,7 @@ describe( 'table selection', () => {
 	}
 
 	function movePressedMouseOver( target ) {
-		moveMouseOver( target, mouseButtonPressed );
+		return moveMouseOver( target, mouseButtonPressed );
 	}
 
 	function moveReleasedMouseOver( target ) {
@@ -469,7 +483,7 @@ describe( 'table selection', () => {
 	}
 
 	function moveMouseOver( target, ...decorators ) {
-		fireEvent( view, 'mousemove', addTarget( target ), ...decorators );
+		return fireEvent( view, 'mousemove', addTarget( target ), ...decorators );
 	}
 
 	function releaseMouseButtonOver( target ) {
@@ -505,5 +519,7 @@ describe( 'table selection', () => {
 		}
 
 		viewDoc.fire( eventName, domEvtDataStub );
+
+		return domEvtDataStub;
 	}
 } );

--- a/theme/table.css
+++ b/theme/table.css
@@ -26,7 +26,7 @@
 		& th {
 			min-width: 2em;
 			padding: .4em;
-			border-color: hsl(0, 0%, 85%);
+			border-color: hsl(0, 0%, 75%);
 		}
 
 		& th {

--- a/theme/tableselection.css
+++ b/theme/tableselection.css
@@ -8,10 +8,3 @@
  * it acts as a message to the builder telling that it should look for the corresponding styles
  * **in the theme** when compiling the editor.
  */
-
-.ck.ck-editor__editable .table table {
-	& td.ck-editor__editable_selected,
-	& th.ck-editor__editable_selected {
-		box-shadow: inset 0 0 0 1px var(--ck-color-focus-border);
-	}
-}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Improved the look of multi-cell selection. Prevented the selection from starting in the fake selection container (see ckeditor/ckeditor5#6114). Closes ckeditor/ckeditor5#6353.

---

The PR lives on top of https://github.com/ckeditor/ckeditor5-table/pull/253.

This is probably one of many PRs in this issue.

### Additional information

Requires: https://github.com/ckeditor/ckeditor5-theme-lark/pull/268.
