### PR TITLE
i/6356: Dropped `DeleteCommand` hooks in favor of the `Model#deleteContent()`

### DIFF
--- a/src/tableselection.js
+++ b/src/tableselection.js
@@ -293,35 +293,29 @@ export default class TableSelection extends Plugin {
 	 */
 	_handleDeleteContent( event, args ) {
 		const [ selection, options ] = args;
+		const model = this.editor.model;
+		const isBackward = !options || options.direction == 'backward';
+		const selectedTableCells = getTableCellsInSelection( selection );
 
-		// This Model#deleteContent() hook supports multiple-cell selections only.
-		// **Note**: It executes Model#deleteContent() itself for each individual cell within
-		// the selection, so this also avoids infinite loops.
-		if ( selection.rangeCount > 1 ) {
-			const model = this.editor.model;
-			const isBackward = !options || options.direction == 'backward';
-			const selectedTableCells = getTableCellsInSelection( selection );
-
-			// There are possible multiple-range selection that have nothing to do with tables.
-			// Let's filter them out and focus on table cells only.
-			if ( selectedTableCells.length ) {
-				event.stop();
-
-				model.change( writer => {
-					const tableCellToSelect = selectedTableCells[ isBackward ? selectedTableCells.length - 1 : 0 ];
-
-					clearTableCellsContents( model, selectedTableCells );
-
-					// The insertContent() helper passes the actual DocumentSelection,
-					// while the deleteContent() helper always operates on the abstract clones.
-					if ( selection.is( 'documentSelection' ) ) {
-						writer.setSelection( tableCellToSelect, 'in' );
-					} else {
-						selection.setTo( tableCellToSelect, 'in' );
-					}
-				} );
-			}
+		if ( !selectedTableCells.length ) {
+			return;
 		}
+
+		event.stop();
+
+		model.change( writer => {
+			const tableCellToSelect = selectedTableCells[ isBackward ? selectedTableCells.length - 1 : 0 ];
+
+			clearTableCellsContents( model, selectedTableCells );
+
+			// The insertContent() helper passes the actual DocumentSelection,
+			// while the deleteContent() helper always operates on the abstract clones.
+			if ( selection.is( 'documentSelection' ) ) {
+				writer.setSelection( tableCellToSelect, 'in' );
+			} else {
+				selection.setTo( tableCellToSelect, 'in' );
+			}
+		} );
 	}
 }
 

--- a/src/tableselection.js
+++ b/src/tableselection.js
@@ -14,7 +14,7 @@ import TableUtils from './tableutils';
 import { setupTableSelectionHighlighting } from './tableselection/converters';
 import MouseSelectionHandler from './tableselection/mouseselectionhandler';
 import { findAncestor } from './commands/utils';
-import { clearTableCellsContents } from './tableselection/utils';
+import { getTableCellsInSelection, clearTableCellsContents } from './tableselection/utils';
 import cropTable from './tableselection/croptable';
 
 import '../theme/tableselection.css';
@@ -300,7 +300,7 @@ export default class TableSelection extends Plugin {
 		if ( selection.rangeCount > 1 ) {
 			const model = this.editor.model;
 			const isBackward = !options || options.direction == 'backward';
-			const selectedTableCells = [ ...this.getSelectedTableCells() ];
+			const selectedTableCells = getTableCellsInSelection( selection );
 
 			// There are possible multiple-range selection that have nothing to do with tables.
 			// Let's filter them out and focus on table cells only.
@@ -308,19 +308,20 @@ export default class TableSelection extends Plugin {
 				event.stop();
 
 				model.change( writer => {
-					clearTableCellsContents( model, selectedTableCells );
+					const tableCellToSelect = selectedTableCells[ isBackward ? selectedTableCells.length - 1 : 0 ];
 
-					const tableCell = isBackward ? this._endElement : this._startElement;
+					clearTableCellsContents( model, selectedTableCells );
 
 					// The insertContent() helper passes the actual DocumentSelection,
 					// while the deleteContent() helper always operates on the abstract clones.
 					if ( selection.is( 'documentSelection' ) ) {
-						writer.setSelection( tableCell, 'in' );
+						writer.setSelection( tableCellToSelect, 'in' );
 					} else {
-						selection.setTo( tableCell, 'in' );
+						selection.setTo( tableCellToSelect, 'in' );
 					}
 				} );
 			}
 		}
 	}
 }
+

--- a/src/tableselection/utils.js
+++ b/src/tableselection/utils.js
@@ -42,7 +42,7 @@ export function getTableCellsInSelection( selection ) {
 	for ( const range of selection.getRanges() ) {
 		const element = getRangeContainedElement( range );
 
-		if ( element.is( 'tableCell' ) ) {
+		if ( element && element.is( 'tableCell' ) ) {
 			cells.push( element );
 		}
 	}

--- a/src/tableselection/utils.js
+++ b/src/tableselection/utils.js
@@ -7,6 +7,8 @@
  * @module table/tableselection/utils
  */
 
+import { getRangeContainedElement } from '../commands/utils';
+
 /**
  * Clears contents of the passed table cells.
  *
@@ -38,10 +40,10 @@ export function getTableCellsInSelection( selection ) {
 	const cells = [];
 
 	for ( const range of selection.getRanges() ) {
-		for ( const item of range.getItems() ) {
-			if ( item.is( 'tableCell' ) ) {
-				cells.push( item );
-			}
+		const element = getRangeContainedElement( range );
+
+		if ( element.is( 'tableCell' ) ) {
+			cells.push( element );
 		}
 	}
 

--- a/src/tableselection/utils.js
+++ b/src/tableselection/utils.js
@@ -17,8 +17,6 @@
  *
  *		clearTableCellsContents( editor.model, tableSelection.getSelectedTableCells() );
  *
- * **Note**: This function is used also by {@link module:table/tableselection~TableSelection#getSelectionAsFragment}
- *
  * @param {module:engine/model/model~Model} model
  * @param {Iterable.<module:engine/model/element~Element>} tableCells
  */
@@ -28,4 +26,24 @@ export function clearTableCellsContents( model, tableCells ) {
 			model.deleteContent( writer.createSelection( tableCell, 'in' ) );
 		}
 	} );
+}
+
+/**
+ * Returns all model cells within the provided model selection.
+ *
+ * @param {Iterable.<module:engine/model/selection~Selection>} selection
+ * @returns {Array.<module:engine/model/element~Element>}
+ */
+export function getTableCellsInSelection( selection ) {
+	const cells = [];
+
+	for ( const range of selection.getRanges() ) {
+		for ( const item of range.getItems() ) {
+			if ( item.is( 'tableCell' ) ) {
+				cells.push( item );
+			}
+		}
+	}
+
+	return cells;
 }

--- a/tests/tableselection-integration.js
+++ b/tests/tableselection-integration.js
@@ -95,6 +95,56 @@ describe( 'table selection', () => {
 					[ '31', '32', '33' ]
 				] ) );
 			} );
+
+			it( 'should work with any arbitrary selection passed to Model#deleteContent() (delete backwards)', () => {
+				const selection = model.createSelection( [
+					model.createRange(
+						model.createPositionFromPath( modelRoot, [ 0, 0, 0 ] ),
+						model.createPositionFromPath( modelRoot, [ 0, 0, 1 ] )
+					),
+					model.createRange(
+						model.createPositionFromPath( modelRoot, [ 0, 0, 1 ] ),
+						model.createPositionFromPath( modelRoot, [ 0, 0, 2 ] )
+					)
+				] );
+
+				model.change( writer => {
+					model.deleteContent( selection );
+					writer.setSelection( selection );
+				} );
+
+				assertEqualMarkup( getModelData( model ), modelTable( [
+					[ '', '[]', '13' ],
+					[ '21', '22', '23' ],
+					[ '31', '32', '33' ]
+				] ) );
+			} );
+
+			it( 'should work with any arbitrary selection passed to Model#deleteContent() (delete forwards)', () => {
+				const selection = model.createSelection( [
+					model.createRange(
+						model.createPositionFromPath( modelRoot, [ 0, 0, 0 ] ),
+						model.createPositionFromPath( modelRoot, [ 0, 0, 1 ] )
+					),
+					model.createRange(
+						model.createPositionFromPath( modelRoot, [ 0, 0, 1 ] ),
+						model.createPositionFromPath( modelRoot, [ 0, 0, 2 ] )
+					)
+				] );
+
+				model.change( writer => {
+					model.deleteContent( selection, {
+						direction: 'forward'
+					} );
+					writer.setSelection( selection );
+				} );
+
+				assertEqualMarkup( getModelData( model ), modelTable( [
+					[ '[]', '', '13' ],
+					[ '21', '22', '23' ],
+					[ '31', '32', '33' ]
+				] ) );
+			} );
 		} );
 
 		describe( 'on user input', () => {

--- a/tests/tableselection-integration.js
+++ b/tests/tableselection-integration.js
@@ -108,15 +108,16 @@ describe( 'table selection', () => {
 
 				viewDocument.fire( 'keydown', { keyCode: getCode( 'x' ) } );
 
-				//                                      figure       table         tbody         tr            td            span
-				const viewSpan = viewDocument.getRoot().getChild( 0 ).getChild( 1 ).getChild( 0 ).getChild( 1 ).getChild( 1 ).getChild( 0 );
+				// Mutate at the place where the document selection was put; it's more realistic
+				// than mutating at some arbitrary position.
+				const placeOfMutation = viewDocument.selection.getFirstRange().start.parent;
 
 				viewDocument.fire( 'mutations', [
 					{
 						type: 'children',
 						oldChildren: [],
 						newChildren: [ new ViewText( 'x' ) ],
-						node: viewSpan
+						node: placeOfMutation
 					}
 				] );
 
@@ -130,15 +131,16 @@ describe( 'table selection', () => {
 			it( 'should not interfere with default key handler if no table selection', () => {
 				viewDocument.fire( 'keydown', { keyCode: getCode( 'x' ) } );
 
-				//                                      figure       table         tbody         tr            td            span
-				const viewSpan = viewDocument.getRoot().getChild( 0 ).getChild( 1 ).getChild( 0 ).getChild( 0 ).getChild( 0 ).getChild( 0 );
+				// Mutate at the place where the document selection was put; it's more realistic
+				// than mutating at some arbitrary position.
+				const placeOfMutation = viewDocument.selection.getFirstRange().start.parent;
 
 				viewDocument.fire( 'mutations', [
 					{
 						type: 'children',
 						oldChildren: [],
 						newChildren: [ new ViewText( 'x' ) ],
-						node: viewSpan
+						node: placeOfMutation
 					}
 				] );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Dropped `DeleteCommand` hooks in favor of the `Model#deleteContent()` hook in the `TableSelection` plugin. Improved `deleteContent()` integration tests. Closes ckeditor/ckeditor5#6356.

---

### Additional information

Requires:
* https://github.com/ckeditor/ckeditor5-engine/pull/1827
* https://github.com/ckeditor/ckeditor5-typing/pull/225
