### PR TITLE
i/6354: Replaced the getRangeContainedElement() helper with Range#getContainedElement()

### DIFF
--- a/src/commands/insertcolumncommand.js
+++ b/src/commands/insertcolumncommand.js
@@ -8,7 +8,7 @@
  */
 
 import Command from '@ckeditor/ckeditor5-core/src/command';
-import { getRangeContainedElement, findAncestor } from './utils';
+import { findAncestor } from './utils';
 
 /**
  * The insert column command.
@@ -75,7 +75,7 @@ export default class InsertColumnCommand extends Command {
 		const referencePosition = insertBefore ? selection.getFirstPosition() : selection.getLastPosition();
 		const referenceRange = insertBefore ? selection.getFirstRange() : selection.getLastRange();
 
-		const tableCell = getRangeContainedElement( referenceRange ) || findAncestor( 'tableCell', referencePosition );
+		const tableCell = referenceRange.getContainedElement() || findAncestor( 'tableCell', referencePosition );
 		const table = tableCell.parent.parent;
 
 		const { column } = tableUtils.getCellLocation( tableCell );

--- a/src/commands/insertrowcommand.js
+++ b/src/commands/insertrowcommand.js
@@ -8,7 +8,7 @@
  */
 
 import Command from '@ckeditor/ckeditor5-core/src/command';
-import { getRangeContainedElement, findAncestor } from './utils';
+import { findAncestor } from './utils';
 
 /**
  * The insert row command.
@@ -74,7 +74,7 @@ export default class InsertRowCommand extends Command {
 		const referencePosition = insertAbove ? selection.getFirstPosition() : selection.getLastPosition();
 		const referenceRange = insertAbove ? selection.getFirstRange() : selection.getLastRange();
 
-		const tableCell = getRangeContainedElement( referenceRange ) || findAncestor( 'tableCell', referencePosition );
+		const tableCell = referenceRange.getContainedElement() || findAncestor( 'tableCell', referencePosition );
 		const tableRow = tableCell.parent;
 		const table = tableRow.parent;
 

--- a/src/commands/utils.js
+++ b/src/commands/utils.js
@@ -30,19 +30,6 @@ export function findAncestor( parentName, positionOrElement ) {
 }
 
 /**
- * Returns an element contained by a range, if it's the only one element contained by the range and if it's fully contained.
- *
- * @param {module:engine/model/range~Range} range
- * @returns {module:engine/model/element~Element|null}
- */
-export function getRangeContainedElement( range ) {
-	const nodeAfterStart = range.start.nodeAfter;
-	const nodeBeforeEnd = range.end.nodeBefore;
-
-	return ( nodeAfterStart && nodeAfterStart.is( 'element' ) && nodeAfterStart == nodeBeforeEnd ) ? nodeAfterStart : null;
-}
-
-/**
  * A common method to update the numeric value. If a value is the default one, it will be unset.
  *
  * @param {String} key An attribute key.

--- a/src/tableselection/utils.js
+++ b/src/tableselection/utils.js
@@ -7,8 +7,6 @@
  * @module table/tableselection/utils
  */
 
-import { getRangeContainedElement } from '../commands/utils';
-
 /**
  * Clears contents of the passed table cells.
  *
@@ -40,7 +38,7 @@ export function getTableCellsInSelection( selection ) {
 	const cells = [];
 
 	for ( const range of selection.getRanges() ) {
-		const element = getRangeContainedElement( range );
+		const element = range.getContainedElement();
 
 		if ( element && element.is( 'tableCell' ) ) {
 			cells.push( element );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Replaced the `getRangeContainedElement()` helper with `Range#getContainedElement()`. See ckeditor/ckeditor5#6364.

---

### Additional information

Requires: https://github.com/ckeditor/ckeditor5-engine/pull/1829

**Next up**: A PR that cleans up `getSelectedTableCells` helpers by taking advantage of `Range#getContainedElement()` (https://github.com/ckeditor/ckeditor5-table/pull/265).