### PR TITLE
Integrated multi cell selection with set column /row header commands

### DIFF
--- a/src/commands/setheadercolumncommand.js
+++ b/src/commands/setheadercolumncommand.js
@@ -71,13 +71,15 @@ export default class SetHeaderColumnCommand extends Command {
 		const tableRow = firstCell.parent;
 		const table = tableRow.parent;
 
-		const selectionColumn = Math.max( tableUtils.getCellLocation( firstCell ).column, tableUtils.getCellLocation( lastCell ).column );
+		const [ selectedColumnMin, selectedColumnMax ] =
+			// Returned cells might not necessary be in order, so make sure to sort it.
+			[ tableUtils.getCellLocation( firstCell ).column, tableUtils.getCellLocation( lastCell ).column ].sort();
 
 		if ( options.forceValue === this.value ) {
 			return;
 		}
 
-		const headingColumnsToSet = this.value ? selectionColumn : selectionColumn + 1;
+		const headingColumnsToSet = this.value ? selectedColumnMin : selectedColumnMax + 1;
 
 		model.change( writer => {
 			updateNumericAttribute( 'headingColumns', headingColumnsToSet, table, writer, 0 );

--- a/src/commands/setheadercolumncommand.js
+++ b/src/commands/setheadercolumncommand.js
@@ -10,7 +10,7 @@
 import Command from '@ckeditor/ckeditor5-core/src/command';
 
 import { updateNumericAttribute } from './utils';
-import { getTableCellsInSelection } from '../tableselection/utils';
+import { getSelectionAffectedTableCells } from '../utils';
 
 /**
  * The header column command.
@@ -33,7 +33,7 @@ export default class SetHeaderColumnCommand extends Command {
 	 */
 	refresh() {
 		const model = this.editor.model;
-		const selectedCells = getTableCellsInSelection( model.document.selection, true );
+		const selectedCells = getSelectionAffectedTableCells( model.document.selection );
 		const isInTable = selectedCells.length > 0;
 
 		this.isEnabled = isInTable;
@@ -65,7 +65,7 @@ export default class SetHeaderColumnCommand extends Command {
 		const model = this.editor.model;
 		const tableUtils = this.editor.plugins.get( 'TableUtils' );
 
-		const selectedCells = getTableCellsInSelection( model.document.selection, true );
+		const selectedCells = getSelectionAffectedTableCells( model.document.selection );
 		const firstCell = selectedCells[ 0 ];
 		const lastCell = selectedCells[ selectedCells.length - 1 ];
 		const tableRow = firstCell.parent;

--- a/src/commands/setheadercolumncommand.js
+++ b/src/commands/setheadercolumncommand.js
@@ -10,6 +10,7 @@
 import Command from '@ckeditor/ckeditor5-core/src/command';
 
 import { findAncestor, updateNumericAttribute } from './utils';
+import { getTableCellsInSelection } from '../tableselection/utils';
 
 /**
  * The header column command.
@@ -32,13 +33,8 @@ export default class SetHeaderColumnCommand extends Command {
 	 */
 	refresh() {
 		const model = this.editor.model;
-		const doc = model.document;
-		const selection = doc.selection;
-
-		const position = selection.getFirstPosition();
-		const tableCell = findAncestor( 'tableCell', position );
-
-		const isInTable = !!tableCell;
+		const selectedCells = getTableCellsInSelection( model.document.selection, true );
+		const isInTable = selectedCells.length > 0;
 
 		this.isEnabled = isInTable;
 
@@ -50,7 +46,7 @@ export default class SetHeaderColumnCommand extends Command {
 		 * @readonly
 		 * @member {Boolean} #value
 		 */
-		this.value = isInTable && this._isInHeading( tableCell, tableCell.parent.parent );
+		this.value = isInTable && selectedCells.every( cell => this._isInHeading( cell, cell.parent.parent ) );
 	}
 
 	/**

--- a/src/commands/setheadercolumncommand.js
+++ b/src/commands/setheadercolumncommand.js
@@ -9,7 +9,7 @@
 
 import Command from '@ckeditor/ckeditor5-core/src/command';
 
-import { findAncestor, updateNumericAttribute } from './utils';
+import { updateNumericAttribute } from './utils';
 import { getTableCellsInSelection } from '../tableselection/utils';
 
 /**
@@ -63,16 +63,15 @@ export default class SetHeaderColumnCommand extends Command {
 	 */
 	execute( options = {} ) {
 		const model = this.editor.model;
-		const doc = model.document;
-		const selection = doc.selection;
 		const tableUtils = this.editor.plugins.get( 'TableUtils' );
 
-		const position = selection.getFirstPosition();
-		const tableCell = findAncestor( 'tableCell', position );
-		const tableRow = tableCell.parent;
+		const selectedCells = getTableCellsInSelection( model.document.selection, true );
+		const firstCell = selectedCells[ 0 ];
+		const lastCell = selectedCells[ selectedCells.length - 1 ];
+		const tableRow = firstCell.parent;
 		const table = tableRow.parent;
 
-		const { column: selectionColumn } = tableUtils.getCellLocation( tableCell );
+		const selectionColumn = Math.max( tableUtils.getCellLocation( firstCell ).column, tableUtils.getCellLocation( lastCell ).column );
 
 		if ( options.forceValue === this.value ) {
 			return;

--- a/src/commands/setheaderrowcommand.js
+++ b/src/commands/setheaderrowcommand.js
@@ -9,7 +9,7 @@
 
 import Command from '@ckeditor/ckeditor5-core/src/command';
 
-import { createEmptyTableCell, findAncestor, updateNumericAttribute } from './utils';
+import { createEmptyTableCell, updateNumericAttribute } from './utils';
 import { getTableCellsInSelection } from '../tableselection/utils';
 import TableWalker from '../tablewalker';
 
@@ -63,22 +63,23 @@ export default class SetHeaderRowCommand extends Command {
 	 */
 	execute( options = {} ) {
 		const model = this.editor.model;
-		const doc = model.document;
-		const selection = doc.selection;
 
-		const position = selection.getFirstPosition();
-		const tableCell = findAncestor( 'tableCell', position );
-		const tableRow = tableCell.parent;
-		const table = tableRow.parent;
+		const selectedCells = getTableCellsInSelection( model.document.selection, true );
+		const firstCell = selectedCells[ 0 ];
+		const lastCell = selectedCells[ selectedCells.length - 1 ];
+		const table = firstCell.parent.parent;
 
 		const currentHeadingRows = table.getAttribute( 'headingRows' ) || 0;
-		const selectionRow = tableRow.index;
+
+		const [ selectedRowMin, selectedRowMax ] =
+			// Returned cells might not necessary be in order, so make sure to sort it.
+			[ firstCell.parent.index, lastCell.parent.index ].sort();
 
 		if ( options.forceValue === this.value ) {
 			return;
 		}
 
-		const headingRowsToSet = this.value ? selectionRow : selectionRow + 1;
+		const headingRowsToSet = this.value ? selectedRowMin : selectedRowMax + 1;
 
 		model.change( writer => {
 			if ( headingRowsToSet ) {

--- a/src/commands/setheaderrowcommand.js
+++ b/src/commands/setheaderrowcommand.js
@@ -10,6 +10,7 @@
 import Command from '@ckeditor/ckeditor5-core/src/command';
 
 import { createEmptyTableCell, findAncestor, updateNumericAttribute } from './utils';
+import { getTableCellsInSelection } from '../tableselection/utils';
 import TableWalker from '../tablewalker';
 
 /**
@@ -32,12 +33,8 @@ export default class SetHeaderRowCommand extends Command {
 	 */
 	refresh() {
 		const model = this.editor.model;
-		const doc = model.document;
-		const selection = doc.selection;
-
-		const position = selection.getFirstPosition();
-		const tableCell = findAncestor( 'tableCell', position );
-		const isInTable = !!tableCell;
+		const selectedCells = getTableCellsInSelection( model.document.selection, true );
+		const isInTable = selectedCells.length > 0;
 
 		this.isEnabled = isInTable;
 
@@ -49,7 +46,7 @@ export default class SetHeaderRowCommand extends Command {
 		 * @readonly
 		 * @member {Boolean} #value
 		 */
-		this.value = isInTable && this._isInHeading( tableCell, tableCell.parent.parent );
+		this.value = isInTable && selectedCells.every( cell => this._isInHeading( cell, cell.parent.parent ) );
 	}
 
 	/**

--- a/src/commands/setheaderrowcommand.js
+++ b/src/commands/setheaderrowcommand.js
@@ -10,7 +10,7 @@
 import Command from '@ckeditor/ckeditor5-core/src/command';
 
 import { createEmptyTableCell, updateNumericAttribute } from './utils';
-import { getTableCellsInSelection } from '../tableselection/utils';
+import { getSelectionAffectedTableCells } from '../utils';
 import TableWalker from '../tablewalker';
 
 /**
@@ -33,7 +33,7 @@ export default class SetHeaderRowCommand extends Command {
 	 */
 	refresh() {
 		const model = this.editor.model;
-		const selectedCells = getTableCellsInSelection( model.document.selection, true );
+		const selectedCells = getSelectionAffectedTableCells( model.document.selection );
 		const isInTable = selectedCells.length > 0;
 
 		this.isEnabled = isInTable;
@@ -64,7 +64,7 @@ export default class SetHeaderRowCommand extends Command {
 	execute( options = {} ) {
 		const model = this.editor.model;
 
-		const selectedCells = getTableCellsInSelection( model.document.selection, true );
+		const selectedCells = getSelectionAffectedTableCells( model.document.selection );
 		const firstCell = selectedCells[ 0 ];
 		const lastCell = selectedCells[ selectedCells.length - 1 ];
 		const table = firstCell.parent.parent;

--- a/tests/commands/setheadercolumncommand.js
+++ b/tests/commands/setheadercolumncommand.js
@@ -200,7 +200,7 @@ describe( 'SetHeaderColumnCommand', () => {
 
 		describe( 'multi-cell selection', () => {
 			describe( 'setting header', () => {
-				it( 'should set it correctly in a middle of single-row, multiple cell selection ', () => {
+				it( 'should set it correctly in a middle of single-row, multiple cell selection', () => {
 					setData( model, modelTable( [
 						[ '00', '01', '02', '03' ]
 					] ) );
@@ -225,7 +225,7 @@ describe( 'SetHeaderColumnCommand', () => {
 					] );
 				} );
 
-				it( 'should set it correctly in a middle of multi-row, multiple cell selection ', () => {
+				it( 'should set it correctly in a middle of multi-row, multiple cell selection', () => {
 					setData( model, modelTable( [
 						[ '00', '01', '02', '03' ],
 						[ '10', '11', '12', '13' ]
@@ -250,6 +250,118 @@ describe( 'SetHeaderColumnCommand', () => {
 					assertSelectedCells( model, [
 						[ 0, 1, 0, 0 ],
 						[ 0, 1, 0, 0 ]
+					] );
+				} );
+
+				it( 'should remove header columns in case of multiple cell selection', () => {
+					setData( model, modelTable( [
+						[ '00', '01', '02', '03' ]
+					], { headingColumns: 4 } ) );
+
+					const tableSelection = editor.plugins.get( TableSelection );
+					const modelRoot = model.document.getRoot();
+					tableSelection._setCellSelection(
+						modelRoot.getNodeByPath( [ 0, 0, 1 ] ),
+						modelRoot.getNodeByPath( [ 0, 0, 2 ] )
+					);
+
+					command.execute();
+
+					assertEqualMarkup( getData( model, { withoutSelection: true } ), modelTable( [
+						[ '00', '01', '02', '03' ]
+					], {
+						headingColumns: 1
+					} ) );
+
+					assertSelectedCells( model, [
+						[ 0, 1, 1, 0 ]
+					] );
+				} );
+
+				it( 'should remove header columns in case of multiple cell selection - reversed order', () => {
+					setData( model, modelTable( [
+						[ '00', '01', '02', '03' ]
+					], {
+						headingColumns: 4
+					} ) );
+
+					const tableSelection = editor.plugins.get( TableSelection );
+					const modelRoot = model.document.getRoot();
+					tableSelection._setCellSelection(
+						modelRoot.getNodeByPath( [ 0, 0, 2 ] ),
+						modelRoot.getNodeByPath( [ 0, 0, 1 ] )
+					);
+
+					command.execute();
+
+					assertEqualMarkup( getData( model, {
+						withoutSelection: true
+					} ), modelTable( [
+						[ '00', '01', '02', '03' ]
+					], {
+						headingColumns: 1
+					} ) );
+
+					assertSelectedCells( model, [
+						[ 0, 1, 1, 0 ]
+					] );
+				} );
+
+				it( 'should respect forceValue=true in case of multiple cell selection', () => {
+					setData( model, modelTable( [
+						[ '00', '01', '02', '03' ]
+					], {
+						headingColumns: 3
+					} ) );
+
+					const tableSelection = editor.plugins.get( TableSelection );
+					const modelRoot = model.document.getRoot();
+					tableSelection._setCellSelection(
+						modelRoot.getNodeByPath( [ 0, 0, 1 ] ),
+						modelRoot.getNodeByPath( [ 0, 0, 2 ] )
+					);
+
+					command.execute( { forceValue: true } );
+
+					assertEqualMarkup( getData( model, {
+						withoutSelection: true
+					} ), modelTable( [
+						[ '00', '01', '02', '03' ]
+					], {
+						headingColumns: 3
+					} ) );
+
+					assertSelectedCells( model, [
+						[ 0, 1, 1, 0 ]
+					] );
+				} );
+
+				it( 'should respect forceValue=false in case of multiple cell selection', () => {
+					setData( model, modelTable( [
+						[ '00', '01', '02', '03' ]
+					], {
+						headingColumns: 1
+					} ) );
+
+					const tableSelection = editor.plugins.get( TableSelection );
+					const modelRoot = model.document.getRoot();
+					tableSelection._setCellSelection(
+						modelRoot.getNodeByPath( [ 0, 0, 1 ] ),
+						modelRoot.getNodeByPath( [ 0, 0, 2 ] )
+					);
+
+					command.execute( { forceValue: false } );
+
+					assertEqualMarkup( getData( model, {
+						withoutSelection: true
+					} ), modelTable( [
+						[ '00', '01', '02', '03' ]
+					], {
+						headingColumns: 1
+					} ) );
+
+					assertSelectedCells( model, [
+						[ 0, 1, 1, 0 ]
 					] );
 				} );
 			} );

--- a/tests/commands/setheaderrowcommand.js
+++ b/tests/commands/setheaderrowcommand.js
@@ -6,7 +6,7 @@
 import ModelTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/modeltesteditor';
 import { getData, setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 import SetHeaderRowCommand from '../../src/commands/setheaderrowcommand';
-import { defaultConversion, defaultSchema, modelTable } from '../_utils/utils';
+import { assertSelectedCells, defaultConversion, defaultSchema, modelTable } from '../_utils/utils';
 import TableSelection from '../../src/tableselection';
 import TableUtils from '../../src/tableutils';
 import { assertEqualMarkup } from '@ckeditor/ckeditor5-utils/tests/_utils/utils';
@@ -241,6 +241,220 @@ describe( 'SetHeaderRowCommand', () => {
 				[ '20' ],
 				[ '30' ]
 			] ) );
+		} );
+
+		describe( 'multi-cell selection', () => {
+			it( 'should set it correctly in a middle of multi-row table', () => {
+				setData( model, modelTable( [
+					[ '00' ],
+					[ '10' ],
+					[ '20' ],
+					[ '30' ]
+				] ) );
+
+				const tableSelection = editor.plugins.get( TableSelection );
+				const modelRoot = model.document.getRoot();
+				tableSelection._setCellSelection(
+					modelRoot.getNodeByPath( [ 0, 1, 0 ] ),
+					modelRoot.getNodeByPath( [ 0, 2, 0 ] )
+				);
+
+				command.execute();
+
+				assertEqualMarkup( getData( model, { withoutSelection: true } ), modelTable( [
+					[ '00' ],
+					[ '10' ],
+					[ '20' ],
+					[ '30' ]
+				], {
+					headingRows: 3
+				} ) );
+
+				assertSelectedCells( model, [
+					[ 0 ],
+					[ 1 ],
+					[ 1 ],
+					[ 0 ]
+				] );
+			} );
+
+			it( 'should set it correctly in a middle of multi-row table - reversed selection', () => {
+				setData( model, modelTable( [
+					[ '00' ],
+					[ '10' ],
+					[ '20' ],
+					[ '30' ]
+				] ) );
+
+				const tableSelection = editor.plugins.get( TableSelection );
+				const modelRoot = model.document.getRoot();
+				tableSelection._setCellSelection(
+					modelRoot.getNodeByPath( [ 0, 2, 0 ] ),
+					modelRoot.getNodeByPath( [ 0, 1, 0 ] )
+				);
+
+				command.execute();
+
+				assertEqualMarkup( getData( model, { withoutSelection: true } ), modelTable( [
+					[ '00' ],
+					[ '10' ],
+					[ '20' ],
+					[ '30' ]
+				], {
+					headingRows: 3
+				} ) );
+
+				assertSelectedCells( model, [
+					[ 0 ],
+					[ 1 ],
+					[ 1 ],
+					[ 0 ]
+				] );
+			} );
+
+			it( 'should set it correctly in a middle of multi-row, multiple cell selection', () => {
+				setData( model, modelTable( [
+					[ '00', '01', '02', '03' ],
+					[ '10', '11', '12', '13' ],
+					[ '20', '21', '22', '23' ],
+					[ '30', '31', '32', '33' ]
+				] ) );
+
+				const tableSelection = editor.plugins.get( TableSelection );
+				const modelRoot = model.document.getRoot();
+				tableSelection._setCellSelection(
+					modelRoot.getNodeByPath( [ 0, 1, 1 ] ),
+					modelRoot.getNodeByPath( [ 0, 2, 2 ] )
+				);
+
+				command.execute();
+
+				assertEqualMarkup( getData( model, { withoutSelection: true } ), modelTable( [
+					[ '00', '01', '02', '03' ],
+					[ '10', '11', '12', '13' ],
+					[ '20', '21', '22', '23' ],
+					[ '30', '31', '32', '33' ]
+				], {
+					headingRows: 3
+				} ) );
+
+				assertSelectedCells( model, [
+					[ 0, 0, 0, 0 ],
+					[ 0, 1, 1, 0 ],
+					[ 0, 1, 1, 0 ],
+					[ 0, 0, 0, 0 ]
+				] );
+			} );
+
+			it( 'should remove header rows in case of multiple cell selection', () => {
+				setData( model, modelTable( [
+					[ '00' ],
+					[ '10' ],
+					[ '20' ],
+					[ '30' ]
+				], { headingRows: 4 } ) );
+
+				const tableSelection = editor.plugins.get( TableSelection );
+				const modelRoot = model.document.getRoot();
+				tableSelection._setCellSelection(
+					modelRoot.getNodeByPath( [ 0, 1, 0 ] ),
+					modelRoot.getNodeByPath( [ 0, 2, 0 ] )
+				);
+
+				command.execute();
+
+				assertEqualMarkup( getData( model, { withoutSelection: true } ), modelTable( [
+					[ '00' ],
+					[ '10' ],
+					[ '20' ],
+					[ '30' ]
+				], {
+					headingRows: 1
+				} ) );
+
+				assertSelectedCells( model, [
+					[ 0 ],
+					[ 1 ],
+					[ 1 ],
+					[ 0 ]
+				] );
+			} );
+
+			it( 'should respect forceValue=true in case of multiple row selection', () => {
+				setData( model, modelTable( [
+					[ '00' ],
+					[ '10' ],
+					[ '20' ],
+					[ '30' ]
+				], {
+					headingRows: 3
+				} ) );
+
+				const tableSelection = editor.plugins.get( TableSelection );
+				const modelRoot = model.document.getRoot();
+				tableSelection._setCellSelection(
+					modelRoot.getNodeByPath( [ 0, 1, 0 ] ),
+					modelRoot.getNodeByPath( [ 0, 2, 0 ] )
+				);
+
+				command.execute( { forceValue: true } );
+
+				assertEqualMarkup( getData( model, {
+					withoutSelection: true
+				} ), modelTable( [
+					[ '00' ],
+					[ '10' ],
+					[ '20' ],
+					[ '30' ]
+				], {
+					headingRows: 3
+				} ) );
+
+				assertSelectedCells( model, [
+					[ 0 ],
+					[ 1 ],
+					[ 1 ],
+					[ 0 ]
+				] );
+			} );
+
+			it( 'should respect forceValue=false in case of multiple cell selection', () => {
+				setData( model, modelTable( [
+					[ '00' ],
+					[ '10' ],
+					[ '20' ],
+					[ '30' ]
+				], {
+					headingRows: 1
+				} ) );
+
+				const tableSelection = editor.plugins.get( TableSelection );
+				const modelRoot = model.document.getRoot();
+				tableSelection._setCellSelection(
+					modelRoot.getNodeByPath( [ 0, 1, 0 ] ),
+					modelRoot.getNodeByPath( [ 0, 2, 0 ] )
+				);
+
+				command.execute( { forceValue: false } );
+
+				assertEqualMarkup( getData( model, {
+					withoutSelection: true
+				} ), modelTable( [
+					[ '00' ],
+					[ '10' ],
+					[ '20' ],
+					[ '30' ]
+				], {
+					headingRows: 1
+				} ) );
+
+				assertSelectedCells( model, [
+					[ 0 ],
+					[ 1 ],
+					[ 1 ],
+					[ 0 ]
+				] );
+			} );
 		} );
 
 		it( 'should respect forceValue parameter #1', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Type: Integrated multi cell selection with set column /row header commands. Closes ckeditor/ckeditor5#6127.

---

### Additional information

After this PR the header command state could get a third state - "mixed" because it's possible to make selection where only part of it contains headers:

![](https://user-images.githubusercontent.com/5353898/76312420-501e3580-62d3-11ea-9035-3c117c3d4c0d.png)

However to simplify things, I implemented it in a way that command state is true only when all selected cells contain header. Otherwise it's `false`.

~I have based this PR on #266 as this PR adds the API that was useful for this enhancement.~ Rebased onto master, after #265 added API that I was mocking before.