### PR TITLE
i/6368: Merge left and right commands should be always enabled if execution does not cross the heading column boundary

### DIFF
--- a/src/commands/mergecellcommand.js
+++ b/src/commands/mergecellcommand.js
@@ -160,7 +160,7 @@ function getHorizontalCell( tableCell, direction, tableUtils ) {
 	const tableRow = tableCell.parent;
 	const table = tableRow.parent;
 	const horizontalCell = direction == 'right' ? tableCell.nextSibling : tableCell.previousSibling;
-	const headingColumns = table.getAttribute( 'headingColumns' ) || 0;
+	const hasHeadingColumns = ( table.getAttribute( 'headingColumns' ) || 0 ) > 0;
 
 	if ( !horizontalCell ) {
 		return;
@@ -177,11 +177,10 @@ function getHorizontalCell( tableCell, direction, tableUtils ) {
 	const leftCellSpan = parseInt( cellOnLeft.getAttribute( 'colspan' ) || 1 );
 
 	const isCellOnLeftInHeadingColumn = isHeadingColumnCell( tableUtils, cellOnLeft, table );
-	const isCellOnRightInRegularColumn = !isHeadingColumnCell( tableUtils, cellOnRight, table );
+	const isCellOnRightInHeadingColumn = isHeadingColumnCell( tableUtils, cellOnRight, table );
 
 	// We cannot merge heading columns cells with regular cells.
-	// We cannot merge regular cells with heading column cells.
-	if ( headingColumns && isCellOnLeftInHeadingColumn && isCellOnRightInRegularColumn ) {
+	if ( hasHeadingColumns && isCellOnLeftInHeadingColumn != isCellOnRightInHeadingColumn ) {
 		return;
 	}
 

--- a/src/commands/mergecellcommand.js
+++ b/src/commands/mergecellcommand.js
@@ -9,7 +9,11 @@
 
 import Command from '@ckeditor/ckeditor5-core/src/command';
 import TableWalker from '../tablewalker';
-import { findAncestor, updateNumericAttribute } from './utils';
+import {
+	findAncestor,
+	updateNumericAttribute,
+	isHeadingColumnCell
+} from './utils';
 
 /**
  * The merge cell command.
@@ -171,13 +175,13 @@ function getHorizontalCell( tableCell, direction, tableUtils ) {
 	const { column: rightCellColumn } = tableUtils.getCellLocation( cellOnRight );
 
 	const leftCellSpan = parseInt( cellOnLeft.getAttribute( 'colspan' ) || 1 );
-	const rightCellSpan = parseInt( cellOnRight.getAttribute( 'colspan' ) || 1 );
 
-	// We cannot merge cells if the result will extend over heading section.
-	const isMergeWithBodyCell = direction == 'right' && ( rightCellColumn + rightCellSpan > headingColumns );
-	const isMergeWithHeadCell = direction == 'left' && ( leftCellColumn + leftCellSpan > headingColumns - 1 );
+	const isCellOnLeftInHeadingColumn = isHeadingColumnCell( tableUtils, cellOnLeft, table );
+	const isCellOnRightInRegularColumn = !isHeadingColumnCell( tableUtils, cellOnRight, table );
 
-	if ( headingColumns && ( isMergeWithBodyCell || isMergeWithHeadCell ) ) {
+	// We cannot merge heading columns cells with regular cells.
+	// We cannot merge regular cells with heading column cells.
+	if ( headingColumns && isCellOnLeftInHeadingColumn && isCellOnRightInRegularColumn ) {
 		return;
 	}
 

--- a/src/commands/setheadercolumncommand.js
+++ b/src/commands/setheadercolumncommand.js
@@ -9,7 +9,11 @@
 
 import Command from '@ckeditor/ckeditor5-core/src/command';
 
-import { findAncestor, updateNumericAttribute } from './utils';
+import {
+	findAncestor,
+	updateNumericAttribute,
+	isHeadingColumnCell
+} from './utils';
 
 /**
  * The header column command.
@@ -37,6 +41,7 @@ export default class SetHeaderColumnCommand extends Command {
 
 		const position = selection.getFirstPosition();
 		const tableCell = findAncestor( 'tableCell', position );
+		const tableUtils = this.editor.plugins.get( 'TableUtils' );
 
 		const isInTable = !!tableCell;
 
@@ -50,7 +55,7 @@ export default class SetHeaderColumnCommand extends Command {
 		 * @readonly
 		 * @member {Boolean} #value
 		 */
-		this.value = isInTable && this._isInHeading( tableCell, tableCell.parent.parent );
+		this.value = isInTable && isHeadingColumnCell( tableUtils, tableCell );
 	}
 
 	/**
@@ -87,23 +92,5 @@ export default class SetHeaderColumnCommand extends Command {
 		model.change( writer => {
 			updateNumericAttribute( 'headingColumns', headingColumnsToSet, table, writer, 0 );
 		} );
-	}
-
-	/**
-	 * Checks if a table cell is in the heading section.
-	 *
-	 * @param {module:engine/model/element~Element} tableCell
-	 * @param {module:engine/model/element~Element} table
-	 * @returns {Boolean}
-	 * @private
-	 */
-	_isInHeading( tableCell, table ) {
-		const headingColumns = parseInt( table.getAttribute( 'headingColumns' ) || 0 );
-
-		const tableUtils = this.editor.plugins.get( 'TableUtils' );
-
-		const { column } = tableUtils.getCellLocation( tableCell );
-
-		return !!headingColumns && column < headingColumns;
 	}
 }

--- a/src/commands/utils.js
+++ b/src/commands/utils.js
@@ -120,7 +120,6 @@ export function addDefaultUnitToNumericValue( value, defaultUnit ) {
  *
  * @param {module:table/tableutils~TableUtils} tableUtils
  * @param {module:engine/model/element~Element} tableCell
- * @param {module:engine/model/element~Element} table
  * @returns {Boolean}
  */
 export function isHeadingColumnCell( tableUtils, tableCell ) {

--- a/src/commands/utils.js
+++ b/src/commands/utils.js
@@ -114,3 +114,19 @@ export function addDefaultUnitToNumericValue( value, defaultUnit ) {
 
 	return `${ numericValue }${ defaultUnit }`;
 }
+
+/**
+ * Checks if a table cell belongs to the heading column section.
+ *
+ * @param {module:table/tableutils~TableUtils} tableUtils
+ * @param {module:engine/model/element~Element} tableCell
+ * @param {module:engine/model/element~Element} table
+ * @returns {Boolean}
+ */
+export function isHeadingColumnCell( tableUtils, tableCell ) {
+	const table = tableCell.parent.parent;
+	const headingColumns = parseInt( table.getAttribute( 'headingColumns' ) || 0 );
+	const { column } = tableUtils.getCellLocation( tableCell );
+
+	return !!headingColumns && column < headingColumns;
+}

--- a/tests/commands/mergecellcommand.js
+++ b/tests/commands/mergecellcommand.js
@@ -95,44 +95,46 @@ describe( 'MergeCellCommand', () => {
 				expect( command.isEnabled ).to.be.false;
 			} );
 
-			it( 'should be false if mergeable cell is in other table section then current cell', () => {
-				setData( model, modelTable( [
-					[ '00[]', '01' ]
-				], { headingColumns: 1 } ) );
+			describe( 'when the heading section is in the table', () => {
+				it( 'should be false if mergeable cell is in other table section then current cell', () => {
+					setData( model, modelTable( [
+						[ '00[]', '01' ]
+					], { headingColumns: 1 } ) );
 
-				expect( command.isEnabled ).to.be.false;
-			} );
+					expect( command.isEnabled ).to.be.false;
+				} );
 
-			it( 'should be false if merged cell would cross heading section (mergeable cell with colspan)', () => {
-				setData( model, modelTable( [
-					[ '00[]', { colspan: 2, contents: '01' }, '02', '03' ]
-				], { headingColumns: 2 } ) );
+				it( 'should be true if merged cell would not cross heading section (mergeable cell with colspan)', () => {
+					setData( model, modelTable( [
+						[ '00[]', { colspan: 2, contents: '01' }, '02', '03' ]
+					], { headingColumns: 3 } ) );
 
-				expect( command.isEnabled ).to.be.false;
-			} );
+					expect( command.isEnabled ).to.be.true;
+				} );
 
-			it( 'should be true if merged cell would not cross heading section (mergeable cell with colspan)', () => {
-				setData( model, modelTable( [
-					[ '00[]', { colspan: 2, contents: '01' }, '02', '03' ]
-				], { headingColumns: 3 } ) );
+				it( 'should be false if merged cell would cross heading section (current cell with colspan)', () => {
+					setData( model, modelTable( [
+						[ { colspan: 2, contents: '00[]' }, '01', '02', '03' ]
+					], { headingColumns: 2 } ) );
 
-				expect( command.isEnabled ).to.be.true;
-			} );
+					expect( command.isEnabled ).to.be.false;
+				} );
 
-			it( 'should be false if merged cell would cross heading section (current cell with colspan)', () => {
-				setData( model, modelTable( [
-					[ { colspan: 2, contents: '00[]' }, '01', '02', '03' ]
-				], { headingColumns: 2 } ) );
+				it( 'should be true if merged cell would not cross heading section (current cell with colspan)', () => {
+					setData( model, modelTable( [
+						[ { colspan: 2, contents: '00[]' }, '01', '02', '03' ]
+					], { headingColumns: 3 } ) );
 
-				expect( command.isEnabled ).to.be.false;
-			} );
+					expect( command.isEnabled ).to.be.true;
+				} );
 
-			it( 'should be true if merged cell would not cross heading section (current cell with colspan)', () => {
-				setData( model, modelTable( [
-					[ { colspan: 2, contents: '00[]' }, '01', '02', '03' ]
-				], { headingColumns: 3 } ) );
+				it( 'should be true if merged cell would not cross the section boundary (regular section)', () => {
+					setData( model, modelTable( [
+						[ '00', '01', '02[]', '03' ]
+					], { headingColumns: 1 } ) );
 
-				expect( command.isEnabled ).to.be.true;
+					expect( command.isEnabled ).to.be.true;
+				} );
 			} );
 		} );
 
@@ -315,20 +317,38 @@ describe( 'MergeCellCommand', () => {
 				expect( command.isEnabled ).to.be.false;
 			} );
 
-			it( 'should be false if mergeable cell is in other table section then current cell', () => {
-				setData( model, modelTable( [
-					[ '00', '01[]' ]
-				], { headingColumns: 1 } ) );
+			describe( 'when the heading section is in the table', () => {
+				it( 'should be false if mergeable cell is in other table section then current cell', () => {
+					setData( model, modelTable( [
+						[ '00', '01[]' ]
+					], { headingColumns: 1 } ) );
 
-				expect( command.isEnabled ).to.be.false;
-			} );
+					expect( command.isEnabled ).to.be.false;
+				} );
 
-			it( 'should be false if merged cell would cross heading section (mergeable cell with colspan)', () => {
-				setData( model, modelTable( [
-					[ { colspan: 2, contents: '00' }, '02[]', '03' ]
-				], { headingColumns: 2 } ) );
+				it( 'should be false if merged cell would cross heading section (mergeable cell with colspan)', () => {
+					setData( model, modelTable( [
+						[ { colspan: 2, contents: '00' }, '02[]', '03' ]
+					], { headingColumns: 2 } ) );
 
-				expect( command.isEnabled ).to.be.false;
+					expect( command.isEnabled ).to.be.false;
+				} );
+
+				it( 'should be true if merged cell would not cross the section boundary (in regular section)', () => {
+					setData( model, modelTable( [
+						[ '00', '01', '02[]', '03' ]
+					], { headingColumns: 1 } ) );
+
+					expect( command.isEnabled ).to.be.true;
+				} );
+
+				it( 'should be true if merged cell would not cross the section boundary (in heading section)', () => {
+					setData( model, modelTable( [
+						[ '00', '01[]', '02', '03' ]
+					], { headingColumns: 2 } ) );
+
+					expect( command.isEnabled ).to.be.true;
+				} );
 			} );
 		} );
 

--- a/tests/commands/utils.js
+++ b/tests/commands/utils.js
@@ -4,20 +4,27 @@
  */
 
 import ModelTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/modeltesteditor';
+import TableUtils from '../../src/tableutils';
 import { setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
-
 import { defaultConversion, defaultSchema, modelTable } from '../_utils/utils';
-
-import { findAncestor } from '../../src/commands/utils';
+import {
+	findAncestor,
+	isHeadingColumnCell
+} from '../../src/commands/utils';
 
 describe( 'commands utils', () => {
-	let editor, model;
+	let editor, model, modelRoot, tableUtils;
 
 	beforeEach( () => {
-		return ModelTestEditor.create()
+		return ModelTestEditor
+			.create( {
+				plugins: [ TableUtils ]
+			} )
 			.then( newEditor => {
 				editor = newEditor;
 				model = editor.model;
+				modelRoot = model.document.getRoot();
+				tableUtils = editor.plugins.get( TableUtils );
 
 				defaultSchema( model.schema );
 				defaultConversion( editor.conversion );
@@ -28,7 +35,7 @@ describe( 'commands utils', () => {
 		return editor.destroy();
 	} );
 
-	describe( 'getParentTable()', () => {
+	describe( 'findAncestor()', () => {
 		it( 'should return undefined if not in table', () => {
 			setData( model, '<paragraph>foo[]</paragraph>' );
 
@@ -42,6 +49,48 @@ describe( 'commands utils', () => {
 
 			expect( parentTable ).to.not.be.undefined;
 			expect( parentTable.is( 'table' ) ).to.be.true;
+		} );
+	} );
+
+	describe( 'isHeadingColumnCell()', () => {
+		it( 'shoud return "true" for heading column cell', () => {
+			setData( model, modelTable( [
+				[ '00', '01', '02', '03' ]
+			], { headingColumns: 2 } ) );
+
+			const tableCell = modelRoot.getNodeByPath( [ 0, 0, 1 ] );
+
+			expect( isHeadingColumnCell( tableUtils, tableCell ) ).to.be.true;
+		} );
+
+		it( 'shoud return "true" for heading column cell with colspan', () => {
+			setData( model, modelTable( [
+				[ { colspan: 2, contents: '00' }, '01', '02', '03' ]
+			], { headingColumns: 2 } ) );
+
+			const tableCell = modelRoot.getNodeByPath( [ 0, 0, 0 ] );
+
+			expect( isHeadingColumnCell( tableUtils, tableCell ) ).to.be.true;
+		} );
+
+		it( 'shoud return "false" for regular column cell', () => {
+			setData( model, modelTable( [
+				[ '00', '01', '02', '03' ]
+			], { headingColumns: 2 } ) );
+
+			const tableCell = modelRoot.getNodeByPath( [ 0, 0, 2 ] );
+
+			expect( isHeadingColumnCell( tableUtils, tableCell ) ).to.be.false;
+		} );
+
+		it( 'shoud return "false" for regular column cell with colspan', () => {
+			setData( model, modelTable( [
+				[ '00', { colspan: 2, contents: '01' }, '02', '03' ]
+			], { headingColumns: 1 } ) );
+
+			const tableCell = modelRoot.getNodeByPath( [ 0, 0, 1 ] );
+
+			expect( isHeadingColumnCell( tableUtils, tableCell ) ).to.be.false;
 		} );
 	} );
 } );

--- a/tests/commands/utils.js
+++ b/tests/commands/utils.js
@@ -7,10 +7,7 @@ import ModelTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/modeltestedit
 import TableUtils from '../../src/tableutils';
 import { setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 import { defaultConversion, defaultSchema, modelTable } from '../_utils/utils';
-import {
-	findAncestor,
-	isHeadingColumnCell
-} from '../../src/commands/utils';
+import { findAncestor, isHeadingColumnCell } from '../../src/commands/utils';
 
 describe( 'commands utils', () => {
 	let editor, model, modelRoot, tableUtils;
@@ -53,7 +50,7 @@ describe( 'commands utils', () => {
 	} );
 
 	describe( 'isHeadingColumnCell()', () => {
-		it( 'shoud return "true" for heading column cell', () => {
+		it( 'should return "true" for a heading column cell', () => {
 			setData( model, modelTable( [
 				[ '00', '01', '02', '03' ]
 			], { headingColumns: 2 } ) );
@@ -63,7 +60,7 @@ describe( 'commands utils', () => {
 			expect( isHeadingColumnCell( tableUtils, tableCell ) ).to.be.true;
 		} );
 
-		it( 'shoud return "true" for heading column cell with colspan', () => {
+		it( 'should return "true" for a heading column cell with colspan', () => {
 			setData( model, modelTable( [
 				[ { colspan: 2, contents: '00' }, '01', '02', '03' ]
 			], { headingColumns: 2 } ) );
@@ -73,7 +70,7 @@ describe( 'commands utils', () => {
 			expect( isHeadingColumnCell( tableUtils, tableCell ) ).to.be.true;
 		} );
 
-		it( 'shoud return "false" for regular column cell', () => {
+		it( 'should return "false" for a regular column cell', () => {
 			setData( model, modelTable( [
 				[ '00', '01', '02', '03' ]
 			], { headingColumns: 2 } ) );
@@ -83,7 +80,7 @@ describe( 'commands utils', () => {
 			expect( isHeadingColumnCell( tableUtils, tableCell ) ).to.be.false;
 		} );
 
-		it( 'shoud return "false" for regular column cell with colspan', () => {
+		it( 'should return "false" for a regular column cell with colspan', () => {
 			setData( model, modelTable( [
 				[ '00', { colspan: 2, contents: '01' }, '02', '03' ]
 			], { headingColumns: 1 } ) );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Merge left and right commands should be always enabled if the execution does not cross the heading column boundary. Closes ckeditor/ckeditor5#6368.
