### PR TITLE
i/6177: Table border styles conversion handler should not throw when it approaches a nested table

### DIFF
--- a/src/converters/tableproperties.js
+++ b/src/converters/tableproperties.js
@@ -60,6 +60,12 @@ export function upcastBorderStyles( conversion, viewElementName ) {
 			return;
 		}
 
+		// This can happen when the upcasted table is nested table. As to why it happens, it remains a mystery.
+		// Take a look at https://github.com/ckeditor/ckeditor5/issues/6177.
+		if ( !data.modelRange ) {
+			data = Object.assign( data, conversionApi.convertChildren( data.viewItem, data.modelCursor ) );
+		}
+
 		const modelElement = [ ...data.modelRange.getItems( { shallow: true } ) ].pop();
 
 		conversionApi.consumable.consume( data.viewItem, matcherPattern );

--- a/tests/tableproperties/tablepropertiesediting.js
+++ b/tests/tableproperties/tablepropertiesediting.js
@@ -210,6 +210,24 @@ describe( 'table properties', () => {
 					assertTRBLAttribute( table, 'borderStyle', null, null, null, 'solid' );
 					assertTRBLAttribute( table, 'borderWidth', null, null, null, '1px' );
 				} );
+
+				// https://github.com/ckeditor/ckeditor5/issues/6177
+				it( 'should upcast tables with nested tables in their cells', () => {
+					editor.setData( '<table style="border:1px solid red">' +
+						'<tr>' +
+							'<td>parent:00</td>' +
+							'<td>' +
+								'<table style="border:1px solid green"><tr><td>child:00</td></tr></table>' +
+							'</td>' +
+						'</tr>' +
+					'</table>' );
+
+					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
+
+					assertTRBLAttribute( table, 'borderColor', 'red' );
+					assertTRBLAttribute( table, 'borderStyle', 'solid' );
+					assertTRBLAttribute( table, 'borderWidth', '1px' );
+				} );
 			} );
 
 			describe( 'downcast conversion', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Table border styles conversion handler should not throw when it approaches a nested table. Closes ckeditor/ckeditor5#6177.
