### PR TITLE
Cutting a table with multiple selected cells in readonly mode should not be possible

### DIFF
--- a/src/tableclipboard.js
+++ b/src/tableclipboard.js
@@ -57,6 +57,10 @@ export default class TableClipboard extends Plugin {
 			return;
 		}
 
+		if ( evt.name == 'cut' && this.editor.isReadOnly ) {
+			return;
+		}
+
 		data.preventDefault();
 		evt.stop();
 

--- a/tests/tableclipboard.js
+++ b/tests/tableclipboard.js
@@ -362,6 +362,8 @@ describe( 'table clipboard', () => {
 			} );
 
 			it( 'should be disabled in a readonly mode', () => {
+				const preventDefaultStub = sinon.stub();
+
 				editor.isReadOnly = true;
 
 				tableSelection._setCellSelection(
@@ -371,7 +373,7 @@ describe( 'table clipboard', () => {
 
 				const data = {
 					dataTransfer: createDataTransfer(),
-					preventDefault: sinon.spy()
+					preventDefault: preventDefaultStub
 				};
 				viewDocument.fire( 'cut', data );
 
@@ -383,6 +385,8 @@ describe( 'table clipboard', () => {
 					[ '10', '11', '12' ],
 					[ '20', '21', '22' ]
 				] ) );
+
+				sinon.assert.calledOnce( preventDefaultStub );
 			} );
 		} );
 	} );

--- a/tests/tableclipboard.js
+++ b/tests/tableclipboard.js
@@ -360,6 +360,30 @@ describe( 'table clipboard', () => {
 					[ '11', '12' ]
 				] ) );
 			} );
+
+			it( 'should be disabled in a readonly mode', () => {
+				editor.isReadOnly = true;
+
+				tableSelection._setCellSelection(
+					modelRoot.getNodeByPath( [ 0, 0, 1 ] ),
+					modelRoot.getNodeByPath( [ 0, 1, 2 ] )
+				);
+
+				const data = {
+					dataTransfer: createDataTransfer(),
+					preventDefault: sinon.spy()
+				};
+				viewDocument.fire( 'cut', data );
+
+				editor.isReadOnly = false;
+
+				expect( data.dataTransfer.getData( 'text/html' ) ).to.be.undefined;
+				assertEqualMarkup( getModelData( model, { withoutSelection: true } ), modelTable( [
+					[ '00', '01', '02' ],
+					[ '10', '11', '12' ],
+					[ '20', '21', '22' ]
+				] ) );
+			} );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Cutting a table with multiple selected cells in readonly mode should not be possible. Closes ckeditor/ckeditor5#6402.