### PR TITLE
Fixed a case where a table with empty row in model would break remove row command

### DIFF
--- a/src/tableutils.js
+++ b/src/tableutils.js
@@ -561,7 +561,8 @@ export default class TableUtils extends Plugin {
 	 */
 	getRows( table ) {
 		return [ ...table.getChildren() ].reduce( ( rows, row ) => {
-			const currentRowCount = parseInt( row.getChild( 0 ).getAttribute( 'rowspan' ) || 1 );
+			const firstCell = row.getChild( 0 );
+			const currentRowCount = firstCell ? parseInt( firstCell.getAttribute( 'rowspan' ) || 1 ) : 0;
 
 			return rows + currentRowCount;
 		}, 0 );

--- a/tests/commands/removerowcommand.js
+++ b/tests/commands/removerowcommand.js
@@ -86,6 +86,16 @@ describe( 'RemoveRowCommand', () => {
 
 			expect( command.isEnabled ).to.be.false;
 		} );
+
+		it( 'should work return a proper value even if there\'s empty row in model', () => {
+			setData( model, modelTable( [
+				[ '00', '01[]' ],
+				[ '10', '11' ],
+				[]
+			] ) );
+
+			expect( command.isEnabled ).to.be.true;
+		} );
 	} );
 
 	describe( 'execute()', () => {

--- a/tests/tableutils.js
+++ b/tests/tableutils.js
@@ -728,5 +728,14 @@ describe( 'TableUtils', () => {
 
 			expect( tableUtils.getRows( root.getNodeByPath( [ 0 ] ) ) ).to.equal( 4 );
 		} );
+
+		it( 'should work correctly with rows containing no cells', () => {
+			setData( model, modelTable( [
+				[ '00', '01' ],
+				[]
+			] ) );
+
+			expect( tableUtils.getRows( root.getNodeByPath( [ 0 ] ) ) ).to.equal( 1 );
+		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Fixed a case where a table with empty row in model would break remove row command. Closes ckeditor/ckeditor5#6422.

---

### Additional information

Detailed issue explanation can be found here: https://github.com/ckeditor/ckeditor5/issues/6422#issuecomment-598155415

The source of this issue is ckeditor/ckeditor5#3280 but it's a bug that is there for a longer time. This adds additional checks in tableutils, so that broken model like that won't cause issues like that in the future.