### PR TITLE
I/6429: Remove row command should not leave empty rows when there are rowspans in the structure

### DIFF
--- a/src/tableutils.js
+++ b/src/tableutils.js
@@ -561,8 +561,7 @@ export default class TableUtils extends Plugin {
 	 */
 	getRows( table ) {
 		return [ ...table.getChildren() ].reduce( ( rows, row ) => {
-			const firstCell = row.getChild( 0 );
-			const currentRowCount = firstCell ? parseInt( firstCell.getAttribute( 'rowspan' ) || 1 ) : 0;
+			const currentRowCount = parseInt( row.getChild( 0 ).getAttribute( 'rowspan' ) || 1 );
 
 			return rows + currentRowCount;
 		}, 0 );

--- a/tests/commands/removecolumncommand.js
+++ b/tests/commands/removecolumncommand.js
@@ -394,5 +394,85 @@ describe( 'RemoveColumnCommand', () => {
 				[ '20', '21' ]
 			] ) );
 		} );
+
+		it( 'should work property if the rowspan is in the first column (#1)', () => {
+			setData( model, modelTable( [
+				[ { rowspan: 2, contents: '00' }, '[]01' ],
+				[ '10' ]
+			] ) );
+
+			command.execute();
+
+			assertEqualMarkup( getData( model ), modelTable( [
+				[ { rowspan: 2, contents: '[]00' } ]
+			] ) );
+		} );
+
+		it( 'should work property if the rowspan is in the first column (#2)', () => {
+			setData( model, modelTable( [
+				[ { rowspan: 2, contents: '00' }, '01' ],
+				[ '[]10' ]
+			] ) );
+
+			command.execute();
+
+			assertEqualMarkup( getData( model ), modelTable( [
+				[ { rowspan: 2, contents: '[]00' } ]
+			] ) );
+		} );
+
+		it( 'should work property if the rowspan is in the first column (#3)', () => {
+			setData( model, modelTable( [
+				[ { rowspan: 2, contents: '00[]' }, '01' ],
+				[ '10' ]
+			] ) );
+
+			command.execute();
+
+			assertEqualMarkup( getData( model ), modelTable( [
+				[ '[]01' ],
+				[ '10' ]
+			] ) );
+		} );
+
+		it( 'should work property if the rowspan is in the last column (#1)', () => {
+			setData( model, modelTable( [
+				[ '[]00', { rowspan: 2, contents: '01' } ],
+				[ '10' ]
+			] ) );
+
+			command.execute();
+
+			assertEqualMarkup( getData( model ), modelTable( [
+				[ { rowspan: 2, contents: '[]01' } ]
+			] ) );
+		} );
+
+		it( 'should work property if the rowspan is in the last column (#2)', () => {
+			setData( model, modelTable( [
+				[ '00', { rowspan: 2, contents: '01' } ],
+				[ '[]10' ]
+			] ) );
+
+			command.execute();
+
+			assertEqualMarkup( getData( model ), modelTable( [
+				[ { rowspan: 2, contents: '[]01' } ]
+			] ) );
+		} );
+
+		it( 'should work property if the rowspan is in the last column (#3)', () => {
+			setData( model, modelTable( [
+				[ '00', { rowspan: 2, contents: '[]01' } ],
+				[ '10' ]
+			] ) );
+
+			command.execute();
+
+			assertEqualMarkup( getData( model ), modelTable( [
+				[ '[]00' ],
+				[ '10' ]
+			] ) );
+		} );
 	} );
 } );

--- a/tests/commands/removerowcommand.js
+++ b/tests/commands/removerowcommand.js
@@ -86,16 +86,6 @@ describe( 'RemoveRowCommand', () => {
 
 			expect( command.isEnabled ).to.be.false;
 		} );
-
-		it( 'should work return a proper value even if there\'s empty row in model', () => {
-			setData( model, modelTable( [
-				[ '00', '01[]' ],
-				[ '10', '11' ],
-				[]
-			] ) );
-
-			expect( command.isEnabled ).to.be.true;
-		} );
 	} );
 
 	describe( 'execute()', () => {

--- a/tests/tableutils.js
+++ b/tests/tableutils.js
@@ -728,14 +728,5 @@ describe( 'TableUtils', () => {
 
 			expect( tableUtils.getRows( root.getNodeByPath( [ 0 ] ) ) ).to.equal( 4 );
 		} );
-
-		it( 'should work correctly with rows containing no cells', () => {
-			setData( model, modelTable( [
-				[ '00', '01' ],
-				[]
-			] ) );
-
-			expect( tableUtils.getRows( root.getNodeByPath( [ 0 ] ) ) ).to.equal( 1 );
-		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Remove row command should not leave empty rows when there are `rowspans` in the structure. Closes ckeditor/ckeditor5#6429.

---

### Additional information

It reverts https://github.com/ckeditor/ckeditor5-table/pull/277 that masked the original issue.
