### PR TITLE
i/6314: Add missing border styling to the table th and td

### DIFF
--- a/theme/table.css
+++ b/theme/table.css
@@ -26,7 +26,12 @@
 		& th {
 			min-width: 2em;
 			padding: .4em;
-			border-color: hsl(0, 0%, 75%);
+			/* After coping a table from the editor and pasting it somewhere in the document, but outside of the editable,
+			table misses some border styles inherited from `.ck-editor__nested-editable` (when table is placed inside the widget).
+			To prevent this, we should define border-width and border-style here as well as a fallback.
+			To reduce LOC, we use shorthand.
+			See https://github.com/ckeditor/ckeditor5/issues/6314 */
+			border: 1px solid hsl(0, 0%, 75%);
 		}
 
 		& th {

--- a/theme/table.css
+++ b/theme/table.css
@@ -26,11 +26,10 @@
 		& th {
 			min-width: 2em;
 			padding: .4em;
-			/* After coping a table from the editor and pasting it somewhere in the document, but outside of the editable,
-			table misses some border styles inherited from `.ck-editor__nested-editable` (when table was placed inside the widget).
-			To prevent this, we should define border-width and border-style here as well as a fallback.
-			To reduce LOC, we use shorthand.
-			See https://github.com/ckeditor/ckeditor5/issues/6314 */
+
+			/* The border is inherited from .ck-editor__nested-editable styles, so theoretically it's not necessary here.
+			However, the border is a content style, so it should use .ck-content (so it works outside the editor).
+			Hence, the duplication. See https://github.com/ckeditor/ckeditor5/issues/6314 */
 			border: 1px solid hsl(0, 0%, 75%);
 		}
 

--- a/theme/table.css
+++ b/theme/table.css
@@ -27,7 +27,7 @@
 			min-width: 2em;
 			padding: .4em;
 			/* After coping a table from the editor and pasting it somewhere in the document, but outside of the editable,
-			table misses some border styles inherited from `.ck-editor__nested-editable` (when table is placed inside the widget).
+			table misses some border styles inherited from `.ck-editor__nested-editable` (when table was placed inside the widget).
 			To prevent this, we should define border-width and border-style here as well as a fallback.
 			To reduce LOC, we use shorthand.
 			See https://github.com/ckeditor/ckeditor5/issues/6314 */


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Added missing border styling after pasting a table outside the editor. Closes ckeditor/ckeditor5#6314.
