### PR TITLE
i/6486: Implemented a button that merges table cells directly from the table toolbar

### DIFF
--- a/docs/features/table.md
+++ b/docs/features/table.md
@@ -335,7 +335,7 @@ The table plugins register the following UI components:
 			<td>The <code>'tableRow'</code> dropdown</td>
 		</tr>
 		<tr>
-			<td>The <code>'mergeTableCells'</code> dropdown</td>
+			<td>The <code>'mergeTableCells'</code> split button</td>
 		</tr>
 		<tr>
 			<td>The <code>'tableProperties'</code> button</td>
@@ -351,7 +351,7 @@ The table plugins register the following UI components:
 #### Toolbars
 
 The {@link module:table/tabletoolbar~TableToolbar} plugin introduces two balloon toolbars for tables.
-* The content toolbar shows up when a table cell is selected and it is anchored to the table. It is possible to {@link module:table/table~TableConfig#contentToolbar configure} its content. Normally, the toolbar contains the table-related tools such as `'tableColumn'`, `'tableRow'`, and `'mergeTableCells'` dropdowns.
+* The content toolbar shows up when a table cell is selected and it is anchored to the table. It is possible to {@link module:table/table~TableConfig#contentToolbar configure} its content. Normally, the toolbar contains the table-related tools such as `'tableColumn'` and `'tableRow'` dropdowns and `'mergeTableCells'` split button.
 * The table toolbar shows up when the whole table is selected, for instance using the widget handler. It is possible to {@link module:table/table~TableConfig#tableToolbar configure} its content.
 
 ### Editor commands

--- a/src/tableui.js
+++ b/src/tableui.js
@@ -26,7 +26,7 @@ import tableMergeCellIcon from './../theme/icons/table-merge-cell.svg';
  * * The `'insertTable'` dropdown,
  * * The `'tableColumn'` dropdown,
  * * The `'tableRow'` dropdown,
- * * The `'mergeTableCells'` dropdown.
+ * * The `'mergeTableCells'` split button.
  *
  * The `'tableColumn'`, `'tableRow'` and `'mergeTableCells'` dropdowns work best with {@link module:table/tabletoolbar~TableToolbar}.
  *

--- a/tests/tableui.js
+++ b/tests/tableui.js
@@ -363,7 +363,7 @@ describe( 'TableUI', () => {
 		} );
 	} );
 
-	describe( 'mergeTableCell dropdown', () => {
+	describe( 'mergeTableCell split button', () => {
 		let dropdown, command;
 
 		beforeEach( () => {

--- a/tests/tableui.js
+++ b/tests/tableui.js
@@ -15,6 +15,7 @@ import InsertTableView from '../src/ui/inserttableview';
 import SwitchButtonView from '@ckeditor/ckeditor5-ui/src/button/switchbuttonview';
 import DropdownView from '@ckeditor/ckeditor5-ui/src/dropdown/dropdownview';
 import ListSeparatorView from '@ckeditor/ckeditor5-ui/src/list/listseparatorview';
+import SplitButtonView from '@ckeditor/ckeditor5-ui/src/dropdown/button/splitbuttonview';
 
 describe( 'TableUI', () => {
 	let editor, element;
@@ -363,10 +364,11 @@ describe( 'TableUI', () => {
 	} );
 
 	describe( 'mergeTableCell dropdown', () => {
-		let dropdown;
+		let dropdown, command;
 
 		beforeEach( () => {
 			dropdown = editor.ui.componentFactory.create( 'mergeTableCells' );
+			command = editor.commands.get( 'mergeTableCells' );
 		} );
 
 		it( 'have button with proper properties set', () => {
@@ -380,6 +382,35 @@ describe( 'TableUI', () => {
 			expect( button.icon ).to.match( /<svg / );
 		} );
 
+		it( 'should have a split button', () => {
+			expect( dropdown.buttonView ).to.be.instanceOf( SplitButtonView );
+		} );
+
+		it( 'should bind #isEnabled to the "mergeTableCells" command', () => {
+			command.isEnabled = false;
+			expect( dropdown.isEnabled ).to.be.false;
+
+			command.isEnabled = true;
+			expect( dropdown.isEnabled ).to.be.true;
+		} );
+
+		it( 'should execute the "mergeTableCells" command when the main part of the split button is clicked', () => {
+			const spy = sinon.stub( editor, 'execute' );
+
+			dropdown.buttonView.fire( 'execute' );
+
+			sinon.assert.calledOnce( spy );
+			sinon.assert.calledWithExactly( spy, 'mergeTableCells' );
+		} );
+
+		it( 'should have the dropdown part of the split button always enabled no matter the "mergeTableCells" command state', () => {
+			command.isEnabled = true;
+			expect( dropdown.buttonView.arrowView.isEnabled ).to.be.true;
+
+			command.isEnabled = false;
+			expect( dropdown.buttonView.arrowView.isEnabled ).to.be.true;
+		} );
+
 		it( 'should have proper items in panel', () => {
 			const listView = dropdown.listView;
 
@@ -390,8 +421,6 @@ describe( 'TableUI', () => {
 				'Merge cell right',
 				'Merge cell down',
 				'Merge cell left',
-				'|',
-				'Merge cells',
 				'|',
 				'Split cell vertically',
 				'Split cell horizontally'
@@ -405,7 +434,6 @@ describe( 'TableUI', () => {
 			const mergeCellRightCommand = editor.commands.get( 'mergeTableCellRight' );
 			const mergeCellDownCommand = editor.commands.get( 'mergeTableCellDown' );
 			const mergeCellLeftCommand = editor.commands.get( 'mergeTableCellLeft' );
-			const mergeCellsCommand = editor.commands.get( 'mergeTableCells' );
 			const splitCellVerticallyCommand = editor.commands.get( 'splitTableCellVertically' );
 			const splitCellHorizontallyCommand = editor.commands.get( 'splitTableCellHorizontally' );
 
@@ -413,7 +441,6 @@ describe( 'TableUI', () => {
 			mergeCellRightCommand.isEnabled = true;
 			mergeCellDownCommand.isEnabled = true;
 			mergeCellLeftCommand.isEnabled = true;
-			mergeCellsCommand.isEnabled = true;
 			splitCellVerticallyCommand.isEnabled = true;
 			splitCellHorizontallyCommand.isEnabled = true;
 
@@ -422,28 +449,21 @@ describe( 'TableUI', () => {
 			const mergeCellDownButton = items.get( 2 );
 			const mergeCellLeftButton = items.get( 3 );
 			// separator
-			const mergeCellsButton = items.get( 5 );
-			// separator
-			const splitVerticallyButton = items.get( 7 );
-			const splitHorizontallyButton = items.get( 8 );
+			const splitVerticallyButton = items.get( 5 );
+			const splitHorizontallyButton = items.get( 6 );
 
 			expect( mergeCellUpButton.children.first.isEnabled ).to.be.true;
 			expect( mergeCellRightButton.children.first.isEnabled ).to.be.true;
 			expect( mergeCellDownButton.children.first.isEnabled ).to.be.true;
 			expect( mergeCellLeftButton.children.first.isEnabled ).to.be.true;
-			expect( mergeCellsButton.children.first.isEnabled ).to.be.true;
 			expect( splitVerticallyButton.children.first.isEnabled ).to.be.true;
 			expect( splitHorizontallyButton.children.first.isEnabled ).to.be.true;
-			expect( dropdown.buttonView.isEnabled ).to.be.true;
 
 			mergeCellUpCommand.isEnabled = false;
 			expect( mergeCellUpButton.children.first.isEnabled ).to.be.false;
-			expect( dropdown.buttonView.isEnabled ).to.be.true;
 
 			mergeCellRightCommand.isEnabled = false;
-
 			expect( mergeCellRightButton.children.first.isEnabled ).to.be.false;
-			expect( dropdown.buttonView.isEnabled ).to.be.true;
 
 			mergeCellDownCommand.isEnabled = false;
 			expect( mergeCellDownButton.children.first.isEnabled ).to.be.false;
@@ -451,16 +471,11 @@ describe( 'TableUI', () => {
 			mergeCellLeftCommand.isEnabled = false;
 			expect( mergeCellLeftButton.children.first.isEnabled ).to.be.false;
 
-			mergeCellsCommand.isEnabled = false;
-			expect( mergeCellsButton.children.first.isEnabled ).to.be.false;
-
 			splitCellVerticallyCommand.isEnabled = false;
 			expect( splitVerticallyButton.children.first.isEnabled ).to.be.false;
 
 			splitCellHorizontallyCommand.isEnabled = false;
 			expect( splitHorizontallyButton.children.first.isEnabled ).to.be.false;
-
-			expect( dropdown.buttonView.isEnabled ).to.be.false;
 		} );
 
 		it( 'should bind items in panel to proper commands (RTL content)', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Implemented a button that merges table cells directly from the table toolbar. Closes ckeditor/ckeditor5#6486.
