### PR TITLE
I/6437: Fix - the table breaks after removing a last header row

### DIFF
--- a/src/converters/downcast.js
+++ b/src/converters/downcast.js
@@ -298,6 +298,7 @@ export function downcastRemoveRow() {
 		const viewStart = mapper.toViewPosition( data.position ).getLastMatchingPosition( value => !value.item.is( 'tr' ) );
 		const viewItem = viewStart.nodeAfter;
 		const tableSection = viewItem.parent;
+		const viewTable = tableSection.parent;
 
 		// Remove associated <tr> from the view.
 		const removeRange = viewWriter.createRangeOn( viewItem );
@@ -307,11 +308,10 @@ export function downcastRemoveRow() {
 			mapper.unbindViewElement( child );
 		}
 
-		// Check if table section has any children left - if not remove it from the view.
-		if ( !tableSection.childCount ) {
-			// No need to unbind anything as table section is not represented in the model.
-			viewWriter.remove( viewWriter.createRangeOn( tableSection ) );
-		}
+		// Cleanup: Ensure that thead & tbody sections are removed if left empty. See ckeditor/ckeditor5#6437.
+		// This happens if removing a row is associated with changing table's headingRows attribute (removing row from a heading section).
+		removeTableSectionIfEmpty( 'thead', viewTable, conversionApi );
+		removeTableSectionIfEmpty( 'tbody', viewTable, conversionApi );
 	}, { priority: 'higher' } );
 }
 

--- a/src/converters/downcast.js
+++ b/src/converters/downcast.js
@@ -209,9 +209,6 @@ export function downcastTableHeadingRowsChange( options = {} ) {
 					renameViewTableCell( tableCell, 'th', conversionApi, asWidget );
 				}
 			}
-
-			// Cleanup: this will remove any empty section from the view which may happen when moving all rows from a table section.
-			removeTableSectionIfEmpty( 'tbody', viewTable, conversionApi );
 		}
 		// The head section has shrunk so move rows from <thead> to <tbody>.
 		else {
@@ -234,10 +231,11 @@ export function downcastTableHeadingRowsChange( options = {} ) {
 			for ( const tableWalkerValue of tableWalker ) {
 				renameViewTableCellIfRequired( tableWalkerValue, tableAttributes, conversionApi, asWidget );
 			}
-
-			// Cleanup: this will remove any empty section from the view which may happen when moving all rows from a table section.
-			removeTableSectionIfEmpty( 'thead', viewTable, conversionApi );
 		}
+
+		// Cleanup: Ensure that thead & tbody sections are removed if left empty after moving rows. See #6437, #6391.
+		removeTableSectionIfEmpty( 'thead', viewTable, conversionApi );
+		removeTableSectionIfEmpty( 'tbody', viewTable, conversionApi );
 
 		function isBetween( index, lower, upper ) {
 			return index > lower && index < upper;
@@ -308,8 +306,7 @@ export function downcastRemoveRow() {
 			mapper.unbindViewElement( child );
 		}
 
-		// Cleanup: Ensure that thead & tbody sections are removed if left empty. See ckeditor/ckeditor5#6437.
-		// This happens if removing a row is associated with changing table's headingRows attribute (removing row from a heading section).
+		// Cleanup: Ensure that thead & tbody sections are removed if left empty after removing rows. See #6437, #6391.
 		removeTableSectionIfEmpty( 'thead', viewTable, conversionApi );
 		removeTableSectionIfEmpty( 'tbody', viewTable, conversionApi );
 	}, { priority: 'higher' } );

--- a/tests/commands/removerowcommand.js
+++ b/tests/commands/removerowcommand.js
@@ -9,22 +9,19 @@ import { getData as getViewData } from '@ckeditor/ckeditor5-engine/src/dev-utils
 
 import RemoveRowCommand from '../../src/commands/removerowcommand';
 import TableSelection from '../../src/tableselection';
-import { defaultConversion, defaultSchema, modelTable, viewTable } from '../_utils/utils';
+import { modelTable, viewTable } from '../_utils/utils';
 import { assertEqualMarkup } from '@ckeditor/ckeditor5-utils/tests/_utils/utils';
+import TableEditing from '../../src/tableediting';
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 
 describe( 'RemoveRowCommand', () => {
 	let editor, model, command;
 
-	beforeEach( () => {
-		return VirtualTestEditor.create( { plugins: [ TableSelection ] } )
-			.then( newEditor => {
-				editor = newEditor;
-				model = editor.model;
-				command = new RemoveRowCommand( editor );
+	beforeEach( async () => {
+		editor = await VirtualTestEditor.create( { plugins: [ Paragraph, TableEditing, TableSelection ] } );
 
-				defaultSchema( model.schema );
-				defaultConversion( editor.conversion );
-			} );
+		model = editor.model;
+		command = new RemoveRowCommand( editor );
 	} );
 
 	afterEach( () => {
@@ -263,11 +260,11 @@ describe( 'RemoveRowCommand', () => {
 					[ '[]40', '41' ]
 				], { headingRows: 1 } ) );
 
-				// The view should also be properly downcasted.
+				// The editing view should also be properly downcasted.
 				assertEqualMarkup( getViewData( editor.editing.view, { withoutSelection: true } ), viewTable( [
 					[ '00', '01' ],
 					[ '40', '41' ]
-				], { headingRows: 1 } ) );
+				], { headingRows: 1, asWidget: true } ) );
 			} );
 
 			it( 'should support removing mixed heading and cell rows', () => {
@@ -447,8 +444,8 @@ describe( 'RemoveRowCommand', () => {
 			setData( model, modelTable( [
 				[ { rowspan: 4, contents: '00' }, { rowspan: 3, contents: '01' }, { rowspan: 2, contents: '02' }, '03', '04' ],
 				[ { rowspan: 2, contents: '13' }, '14' ],
-				[ '22[]', '23', '24' ],
-				[ '30', '31', '32', '33', '34' ]
+				[ '22[]', '24' ],
+				[ '31', '32', '33', '34' ]
 			] ) );
 
 			command.execute();
@@ -456,7 +453,7 @@ describe( 'RemoveRowCommand', () => {
 			assertEqualMarkup( getData( model ), modelTable( [
 				[ { rowspan: 3, contents: '00' }, { rowspan: 2, contents: '01' }, { rowspan: 2, contents: '02' }, '03', '04' ],
 				[ '13', '14' ],
-				[ '30', '31', '[]32', '33', '34' ]
+				[ '31', '32', '[]33', '34' ]
 			] ) );
 		} );
 

--- a/tests/converters/downcast.js
+++ b/tests/converters/downcast.js
@@ -1286,6 +1286,8 @@ describe( 'downcast converters', () => {
 				const table = root.getChild( 0 );
 
 				model.change( writer => {
+					// Removing row from a heading section changes requires changing heading rows attribute.
+					writer.setAttribute( 'headingRows', 1, table );
 					writer.remove( table.getChild( 0 ) );
 				} );
 
@@ -1317,6 +1319,8 @@ describe( 'downcast converters', () => {
 				const table = root.getChild( 0 );
 
 				model.change( writer => {
+					// Removing row from a heading section changes requires changing heading rows attribute.
+					writer.setAttribute( 'headingRows', 1, table );
 					writer.remove( table.getChild( 1 ) );
 				} );
 
@@ -1348,7 +1352,8 @@ describe( 'downcast converters', () => {
 				const table = root.getChild( 0 );
 
 				model.change( writer => {
-					writer.setAttribute( 'headingRows', 0, table );
+					// Removing row from a heading section changes requires changing heading rows attribute.
+					writer.removeAttribute( 'headingRows', table );
 					writer.remove( table.getChild( 0 ) );
 				} );
 

--- a/tests/converters/downcast.js
+++ b/tests/converters/downcast.js
@@ -1310,6 +1310,7 @@ describe( 'downcast converters', () => {
 				);
 			} );
 
+			// Might be a misuse of API or other operation - must work either wey. See #6437, #6391.
 			it( 'should react to removed row form the end of a heading rows (no body rows)', () => {
 				setModelData( model, modelTable( [
 					[ '00[]', '01' ],
@@ -1322,6 +1323,43 @@ describe( 'downcast converters', () => {
 					// Removing row from a heading section changes requires changing heading rows attribute.
 					writer.setAttribute( 'headingRows', 1, table );
 					writer.remove( table.getChild( 1 ) );
+				} );
+
+				assertEqualMarkup( getViewData( view, { withoutSelection: true } ),
+					'<figure class="ck-widget ck-widget_with-selection-handle table" contenteditable="false">' +
+						'<div class="ck ck-widget__selection-handle"></div>' +
+						'<table>' +
+							'<thead>' +
+								'<tr>' +
+									'<th class="ck-editor__editable ck-editor__nested-editable" contenteditable="true">' +
+										'<span style="display:inline-block">00</span>' +
+									'</th>' +
+									'<th class="ck-editor__editable ck-editor__nested-editable" contenteditable="true">' +
+										'<span style="display:inline-block">01</span>' +
+									'</th>' +
+								'</tr>' +
+							'</thead>' +
+						'</table>' +
+					'</figure>'
+				);
+			} );
+
+			// Might be a misuse of API or other operation - must work either wey. See #6437, #6391.
+			it( 'should react to removed row form the end of a heading rows (no body rows, using enqueueChange())', () => {
+				setModelData( model, modelTable( [
+					[ '00[]', '01' ],
+					[ '10', '11' ]
+				], { headingRows: 2 } ) );
+
+				const table = root.getChild( 0 );
+
+				model.change( writer => {
+					// Removing row from a heading section changes requires changing heading rows attribute.
+					writer.remove( table.getChild( 1 ) );
+
+					model.enqueueChange( writer => {
+						writer.setAttribute( 'headingRows', 1, table );
+					} );
 				} );
 
 				assertEqualMarkup( getViewData( view, { withoutSelection: true } ),

--- a/tests/converters/downcast.js
+++ b/tests/converters/downcast.js
@@ -1303,7 +1303,6 @@ describe( 'downcast converters', () => {
 				);
 			} );
 
-			// Might be a misuse of API or other operation - must work either wey. See #6437, #6391.
 			it( 'should react to removed row form the end of a heading rows (no body rows)', () => {
 				setModelData( model, modelTable( [
 					[ '00[]', '01' ],
@@ -1337,38 +1336,47 @@ describe( 'downcast converters', () => {
 				);
 			} );
 
-			// Might be a misuse of API or other operation - must work either wey. See #6437, #6391.
-			it( 'should react to removed row form the end of a heading rows (no body rows, using enqueueChange())', () => {
+			it( 'should react to removed row form the end of a heading rows (first cell in body has colspan)', () => {
 				setModelData( model, modelTable( [
-					[ '00[]', '01' ],
-					[ '10', '11' ]
-				], { headingRows: 2 } ) );
+					[ '00[]', '01', '02', '03' ],
+					[ { rowspan: 2, colspan: 2, contents: '10' }, '12', '13' ],
+					[ '22', '23' ]
+				], { headingRows: 1 } ) );
 
 				const table = root.getChild( 0 );
 
 				model.change( writer => {
 					// Removing row from a heading section changes requires changing heading rows attribute.
-					writer.remove( table.getChild( 1 ) );
-
-					model.enqueueChange( writer => {
-						writer.setAttribute( 'headingRows', 1, table );
-					} );
+					writer.remove( table.getChild( 0 ) );
+					writer.setAttribute( 'headingRows', 0, table );
 				} );
 
 				assertEqualMarkup( getViewData( view, { withoutSelection: true } ),
 					'<figure class="ck-widget ck-widget_with-selection-handle table" contenteditable="false">' +
-						'<div class="ck ck-widget__selection-handle"></div>' +
+					'<div class="ck ck-widget__selection-handle"></div>' +
 						'<table>' +
-							'<thead>' +
+							'<tbody>' +
 								'<tr>' +
-									'<th class="ck-editor__editable ck-editor__nested-editable" contenteditable="true">' +
-										'<span style="display:inline-block">00</span>' +
-									'</th>' +
-									'<th class="ck-editor__editable ck-editor__nested-editable" contenteditable="true">' +
-										'<span style="display:inline-block">01</span>' +
-									'</th>' +
+									'<td class="ck-editor__editable ck-editor__nested-editable" ' +
+										'colspan="2" contenteditable="true" rowspan="2">' +
+										'<span style="display:inline-block">10</span>' +
+									'</td>' +
+									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true">' +
+										'<span style="display:inline-block">12</span>' +
+									'</td>' +
+									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true">' +
+										'<span style="display:inline-block">13</span>' +
+									'</td>' +
 								'</tr>' +
-							'</thead>' +
+								'<tr>' +
+									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true">' +
+										'<span style="display:inline-block">22</span>' +
+									'</td>' +
+									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true">' +
+										'<span style="display:inline-block">23</span>' +
+									'</td>' +
+								'</tr>' +
+							'</tbody>' +
 						'</table>' +
 					'</figure>'
 				);

--- a/tests/converters/downcast.js
+++ b/tests/converters/downcast.js
@@ -42,24 +42,25 @@ describe( 'downcast converters', () => {
 
 	testUtils.createSinonSandbox();
 
-	beforeEach( () => {
-		// Most tests assume non-edge environment but we do not set `contenteditable=false` on Edge so stub `env.isEdge`.
-		testUtils.sinon.stub( env, 'isEdge' ).get( () => false );
-
-		return VirtualTestEditor.create()
-			.then( newEditor => {
-				editor = newEditor;
-				model = editor.model;
-				doc = model.document;
-				root = doc.getRoot( 'main' );
-				view = editor.editing.view;
-
-				defaultSchema( model.schema );
-				defaultConversion( editor.conversion );
-			} );
-	} );
-
 	describe( 'downcastInsertTable()', () => {
+		// The beforeEach is duplicated due to ckeditor/ckeditor5#6574. New test are written using TableEdting.
+		beforeEach( () => {
+			// Most tests assume non-edge environment but we do not set `contenteditable=false` on Edge so stub `env.isEdge`.
+			testUtils.sinon.stub( env, 'isEdge' ).get( () => false );
+
+			return VirtualTestEditor.create()
+				.then( newEditor => {
+					editor = newEditor;
+					model = editor.model;
+					doc = model.document;
+					root = doc.getRoot( 'main' );
+					view = editor.editing.view;
+
+					defaultSchema( model.schema );
+					defaultConversion( editor.conversion );
+				} );
+		} );
+
 		it( 'should create table with tbody', () => {
 			setModelData( model, modelTable( [ [ '' ] ] ) );
 
@@ -355,6 +356,24 @@ describe( 'downcast converters', () => {
 	} );
 
 	describe( 'downcastInsertRow()', () => {
+		// The beforeEach is duplicated due to ckeditor/ckeditor5#6574. New test are written using TableEdting.
+		beforeEach( () => {
+			// Most tests assume non-edge environment but we do not set `contenteditable=false` on Edge so stub `env.isEdge`.
+			testUtils.sinon.stub( env, 'isEdge' ).get( () => false );
+
+			return VirtualTestEditor.create()
+				.then( newEditor => {
+					editor = newEditor;
+					model = editor.model;
+					doc = model.document;
+					root = doc.getRoot( 'main' );
+					view = editor.editing.view;
+
+					defaultSchema( model.schema );
+					defaultConversion( editor.conversion );
+				} );
+		} );
+
 		it( 'should react to changed rows', () => {
 			setModelData( model, modelTable( [
 				[ '00', '01' ]
@@ -592,6 +611,24 @@ describe( 'downcast converters', () => {
 	} );
 
 	describe( 'downcastInsertCell()', () => {
+		// The beforeEach is duplicated due to ckeditor/ckeditor5#6574. New test are written using TableEdting.
+		beforeEach( () => {
+			// Most tests assume non-edge environment but we do not set `contenteditable=false` on Edge so stub `env.isEdge`.
+			testUtils.sinon.stub( env, 'isEdge' ).get( () => false );
+
+			return VirtualTestEditor.create()
+				.then( newEditor => {
+					editor = newEditor;
+					model = editor.model;
+					doc = model.document;
+					root = doc.getRoot( 'main' );
+					view = editor.editing.view;
+
+					defaultSchema( model.schema );
+					defaultConversion( editor.conversion );
+				} );
+		} );
+
 		it( 'should add tableCell on proper index in tr', () => {
 			setModelData( model, modelTable( [
 				[ '00', '01' ]
@@ -736,6 +773,24 @@ describe( 'downcast converters', () => {
 	} );
 
 	describe( 'downcastTableHeadingColumnsChange()', () => {
+		// The beforeEach is duplicated due to ckeditor/ckeditor5#6574. New test are written using TableEdting.
+		beforeEach( () => {
+			// Most tests assume non-edge environment but we do not set `contenteditable=false` on Edge so stub `env.isEdge`.
+			testUtils.sinon.stub( env, 'isEdge' ).get( () => false );
+
+			return VirtualTestEditor.create()
+				.then( newEditor => {
+					editor = newEditor;
+					model = editor.model;
+					doc = model.document;
+					root = doc.getRoot( 'main' );
+					view = editor.editing.view;
+
+					defaultSchema( model.schema );
+					defaultConversion( editor.conversion );
+				} );
+		} );
+
 		it( 'should work for adding heading columns', () => {
 			setModelData( model, modelTable( [
 				[ '00', '01' ],
@@ -912,6 +967,24 @@ describe( 'downcast converters', () => {
 	} );
 
 	describe( 'downcastTableHeadingRowsChange()', () => {
+		// The beforeEach is duplicated due to ckeditor/ckeditor5#6574. New test are written using TableEdting.
+		beforeEach( () => {
+			// Most tests assume non-edge environment but we do not set `contenteditable=false` on Edge so stub `env.isEdge`.
+			testUtils.sinon.stub( env, 'isEdge' ).get( () => false );
+
+			return VirtualTestEditor.create()
+				.then( newEditor => {
+					editor = newEditor;
+					model = editor.model;
+					doc = model.document;
+					root = doc.getRoot( 'main' );
+					view = editor.editing.view;
+
+					defaultSchema( model.schema );
+					defaultConversion( editor.conversion );
+				} );
+		} );
+
 		it( 'should work for adding heading rows', () => {
 			setModelData( model, modelTable( [
 				[ '00', '01' ],
@@ -1126,6 +1199,24 @@ describe( 'downcast converters', () => {
 	} );
 
 	describe( 'downcastRemoveRow()', () => {
+		// The beforeEach is duplicated due to ckeditor/ckeditor5#6574. New test are written using TableEdting.
+		beforeEach( () => {
+			// Most tests assume non-edge environment but we do not set `contenteditable=false` on Edge so stub `env.isEdge`.
+			testUtils.sinon.stub( env, 'isEdge' ).get( () => false );
+
+			return VirtualTestEditor.create()
+				.then( newEditor => {
+					editor = newEditor;
+					model = editor.model;
+					doc = model.document;
+					root = doc.getRoot( 'main' );
+					view = editor.editing.view;
+
+					defaultSchema( model.schema );
+					defaultConversion( editor.conversion );
+				} );
+		} );
+
 		it( 'should react to removed row from the beginning of a tbody', () => {
 			setModelData( model, modelTable( [
 				[ '00[]', '01' ],

--- a/tests/converters/downcast.js
+++ b/tests/converters/downcast.js
@@ -45,7 +45,7 @@ describe( 'downcast converters', () => {
 	testUtils.createSinonSandbox();
 
 	describe( 'downcastInsertTable()', () => {
-		// The beforeEach is duplicated due to ckeditor/ckeditor5#6574. New test are written using TableEdting.
+		// The beforeEach is duplicated due to ckeditor/ckeditor5#6574. New test are written using TableEditing.
 		beforeEach( () => {
 			// Most tests assume non-edge environment but we do not set `contenteditable=false` on Edge so stub `env.isEdge`.
 			testUtils.sinon.stub( env, 'isEdge' ).get( () => false );
@@ -358,7 +358,7 @@ describe( 'downcast converters', () => {
 	} );
 
 	describe( 'downcastInsertRow()', () => {
-		// The beforeEach is duplicated due to ckeditor/ckeditor5#6574. New test are written using TableEdting.
+		// The beforeEach is duplicated due to ckeditor/ckeditor5#6574. New test are written using TableEditing.
 		beforeEach( () => {
 			// Most tests assume non-edge environment but we do not set `contenteditable=false` on Edge so stub `env.isEdge`.
 			testUtils.sinon.stub( env, 'isEdge' ).get( () => false );
@@ -613,7 +613,7 @@ describe( 'downcast converters', () => {
 	} );
 
 	describe( 'downcastInsertCell()', () => {
-		// The beforeEach is duplicated due to ckeditor/ckeditor5#6574. New test are written using TableEdting.
+		// The beforeEach is duplicated due to ckeditor/ckeditor5#6574. New test are written using TableEditing.
 		beforeEach( () => {
 			// Most tests assume non-edge environment but we do not set `contenteditable=false` on Edge so stub `env.isEdge`.
 			testUtils.sinon.stub( env, 'isEdge' ).get( () => false );
@@ -775,7 +775,7 @@ describe( 'downcast converters', () => {
 	} );
 
 	describe( 'downcastTableHeadingColumnsChange()', () => {
-		// The beforeEach is duplicated due to ckeditor/ckeditor5#6574. New test are written using TableEdting.
+		// The beforeEach is duplicated due to ckeditor/ckeditor5#6574. New test are written using TableEditing.
 		beforeEach( () => {
 			// Most tests assume non-edge environment but we do not set `contenteditable=false` on Edge so stub `env.isEdge`.
 			testUtils.sinon.stub( env, 'isEdge' ).get( () => false );
@@ -953,15 +953,15 @@ describe( 'downcast converters', () => {
 				assertEqualMarkup( getViewData( view, { withoutSelection: true } ),
 					'<figure class="ck-widget ck-widget_with-selection-handle table" contenteditable="false">' +
 					'<div class="ck ck-widget__selection-handle"></div>' +
-						'<table>' +
-							'<thead>' +
-								'<tr>' +
-									'<th class="ck-editor__editable ck-editor__nested-editable" contenteditable="true">' +
-										'<span style="display:inline-block">00</span>' +
-									'</th>' +
-								'</tr>' +
-							'</thead>' +
-						'</table>' +
+					'<table>' +
+					'<thead>' +
+					'<tr>' +
+					'<th class="ck-editor__editable ck-editor__nested-editable" contenteditable="true">' +
+					'<span style="display:inline-block">00</span>' +
+					'</th>' +
+					'</tr>' +
+					'</thead>' +
+					'</table>' +
 					'</figure>'
 				);
 			} );
@@ -969,208 +969,201 @@ describe( 'downcast converters', () => {
 	} );
 
 	describe( 'downcastTableHeadingRowsChange()', () => {
-		// The beforeEach is duplicated due to ckeditor/ckeditor5#6574. New test are written using TableEdting.
+		// The beforeEach is duplicated due to ckeditor/ckeditor5#6574. New test are written using TableEditing.
 		beforeEach( () => {
 			// Most tests assume non-edge environment but we do not set `contenteditable=false` on Edge so stub `env.isEdge`.
 			testUtils.sinon.stub( env, 'isEdge' ).get( () => false );
 
-			return VirtualTestEditor.create()
+			return VirtualTestEditor.create( { plugins: [ Paragraph, TableEditing ] } )
 				.then( newEditor => {
 					editor = newEditor;
 					model = editor.model;
 					doc = model.document;
 					root = doc.getRoot( 'main' );
 					view = editor.editing.view;
-
-					defaultSchema( model.schema );
-					defaultConversion( editor.conversion );
 				} );
 		} );
 
-		it( 'should work for adding heading rows', () => {
-			setModelData( model, modelTable( [
-				[ '00', '01' ],
-				[ '10', '11' ],
-				[ '20', '21' ]
-			] ) );
+		// The heading rows change downcast conversion is not executed in data pipeline.
+		describe( 'editing pipeline', () => {
+			it( 'should work for adding heading rows', () => {
+				setModelData( model, modelTable( [
+					[ '00', '01' ],
+					[ '10', '11' ],
+					[ '20', '21' ]
+				] ) );
 
-			const table = root.getChild( 0 );
+				const table = root.getChild( 0 );
 
-			model.change( writer => {
-				writer.setAttribute( 'headingRows', 2, table );
+				model.change( writer => {
+					writer.setAttribute( 'headingRows', 2, table );
+				} );
+
+				assertEqualMarkup( getViewData( view, { withoutSelection: true } ), viewTable( [
+					[ '00', '01' ],
+					[ '10', '11' ],
+					[ '20', '21' ]
+				], { headingRows: 2, asWidget: true } ) );
 			} );
 
-			assertEqualMarkup( getViewData( view, { withoutSelection: true } ), viewTable( [
-				[ '00', '01' ],
-				[ '10', '11' ],
-				[ '20', '21' ]
-			], { headingRows: 2 } ) );
-		} );
+			it( 'should work for changing number of heading rows to a bigger number', () => {
+				setModelData( model, modelTable( [
+					[ '00', '01' ],
+					[ '10', '11' ],
+					[ '20', '21' ]
+				], { headingRows: 1 } ) );
 
-		it( 'should work for changing number of heading rows to a bigger number', () => {
-			setModelData( model, modelTable( [
-				[ '00', '01' ],
-				[ '10', '11' ],
-				[ '20', '21' ]
-			], { headingRows: 1 } ) );
+				const table = root.getChild( 0 );
 
-			const table = root.getChild( 0 );
+				model.change( writer => {
+					writer.setAttribute( 'headingRows', 2, table );
+				} );
 
-			model.change( writer => {
-				writer.setAttribute( 'headingRows', 2, table );
+				assertEqualMarkup( getViewData( view, { withoutSelection: true } ), viewTable( [
+					[ '00', '01' ],
+					[ '10', '11' ],
+					[ '20', '21' ]
+				], { headingRows: 2, asWidget: true } ) );
 			} );
 
-			assertEqualMarkup( getViewData( view, { withoutSelection: true } ), viewTable( [
-				[ '00', '01' ],
-				[ '10', '11' ],
-				[ '20', '21' ]
-			], { headingRows: 2 } ) );
-		} );
+			it( 'should work for changing number of heading rows to a smaller number', () => {
+				setModelData( model, modelTable( [
+					[ '00', '01' ],
+					[ '10', '11' ],
+					[ '20', '21' ],
+					[ '30', '31' ]
+				], { headingRows: 3 } ) );
 
-		it( 'should work for changing number of heading rows to a smaller number', () => {
-			setModelData( model, modelTable( [
-				[ '00', '01' ],
-				[ '10', '11' ],
-				[ '20', '21' ],
-				[ '30', '31' ]
-			], { headingRows: 3 } ) );
+				const table = root.getChild( 0 );
 
-			const table = root.getChild( 0 );
+				model.change( writer => {
+					writer.setAttribute( 'headingRows', 2, table );
+				} );
 
-			model.change( writer => {
-				writer.setAttribute( 'headingRows', 2, table );
+				assertEqualMarkup( getViewData( view, { withoutSelection: true } ), viewTable( [
+					[ '00', '01' ],
+					[ '10', '11' ],
+					[ '20', '21' ],
+					[ '30', '31' ]
+				], { headingRows: 2, asWidget: true } ) );
 			} );
 
-			assertEqualMarkup( getViewData( view, { withoutSelection: true } ), viewTable( [
-				[ '00', '01' ],
-				[ '10', '11' ],
-				[ '20', '21' ],
-				[ '30', '31' ]
-			], { headingRows: 2 } ) );
-		} );
+			it( 'should work for removing heading rows', () => {
+				setModelData( model, modelTable( [
+					[ '00', '01' ],
+					[ '10', '11' ]
+				], { headingRows: 2 } ) );
 
-		it( 'should work for removing heading rows', () => {
-			setModelData( model, modelTable( [
-				[ '00', '01' ],
-				[ '10', '11' ]
-			], { headingRows: 2 } ) );
+				const table = root.getChild( 0 );
 
-			const table = root.getChild( 0 );
+				model.change( writer => {
+					writer.removeAttribute( 'headingRows', table );
+				} );
 
-			model.change( writer => {
-				writer.removeAttribute( 'headingRows', table );
+				assertEqualMarkup( getViewData( view, { withoutSelection: true } ), viewTable( [
+					[ '00', '01' ],
+					[ '10', '11' ]
+				], { asWidget: true } ) );
 			} );
 
-			assertEqualMarkup( getViewData( view, { withoutSelection: true } ), viewTable( [
-				[ '00', '01' ],
-				[ '10', '11' ]
-			] ) );
-		} );
+			it( 'should work for making heading rows without tbody', () => {
+				setModelData( model, modelTable( [
+					[ '00', '01' ],
+					[ '10', '11' ]
+				] ) );
 
-		it( 'should work for making heading rows without tbody', () => {
-			setModelData( model, modelTable( [
-				[ '00', '01' ],
-				[ '10', '11' ]
-			] ) );
+				const table = root.getChild( 0 );
 
-			const table = root.getChild( 0 );
+				model.change( writer => {
+					writer.setAttribute( 'headingRows', 2, table );
+				} );
 
-			model.change( writer => {
-				writer.setAttribute( 'headingRows', 2, table );
+				assertEqualMarkup( getViewData( view, { withoutSelection: true } ), viewTable( [
+					[ '00', '01' ],
+					[ '10', '11' ]
+				], { headingRows: 2, asWidget: true } ) );
 			} );
 
-			assertEqualMarkup( getViewData( view, { withoutSelection: true } ), viewTable( [
-				[ '00', '01' ],
-				[ '10', '11' ]
-			], { headingRows: 2 } ) );
-		} );
+			it( 'should be possible to overwrite', () => {
+				editor.conversion.attributeToAttribute( {
+					model: 'headingRows',
+					view: 'headingRows',
+					converterPriority: 'high'
+				} );
+				setModelData( model, modelTable( [ [ '00' ] ] ) );
 
-		it( 'should be possible to overwrite', () => {
-			editor.conversion.attributeToAttribute( { model: 'headingRows', view: 'headingRows', converterPriority: 'high' } );
-			setModelData( model, modelTable( [ [ '00' ] ] ) );
+				const table = root.getChild( 0 );
 
-			const table = root.getChild( 0 );
+				model.change( writer => {
+					writer.setAttribute( 'headingRows', 1, table );
+				} );
 
-			model.change( writer => {
-				writer.setAttribute( 'headingRows', 1, table );
+				assertEqualMarkup( getViewData( view, { withoutSelection: true } ),
+					'<figure class="ck-widget ck-widget_with-selection-handle table" contenteditable="false" headingRows="1">' +
+						'<div class="ck ck-widget__selection-handle"></div>' +
+						'<table>' +
+							'<tbody>' +
+								'<tr>' +
+									'<td class="ck-editor__editable ck-editor__nested-editable" contenteditable="true">' +
+										'<span style="display:inline-block">00</span>' +
+									'</td>' +
+								'</tr>' +
+							'</tbody>' +
+						'</table>' +
+					'</figure>'
+				);
 			} );
 
-			assertEqualMarkup( getViewData( view, { withoutSelection: true } ),
-				'<figure class="table" headingRows="1">' +
-					'<table>' +
-						'<tbody>' +
-							'<tr><td>00</td></tr>' +
-						'</tbody>' +
-					'</table>' +
-				'</figure>'
-			);
-		} );
+			it( 'should work with adding table rows at the beginning of a table', () => {
+				setModelData( model, modelTable( [
+					[ '00', '01' ],
+					[ '10', '11' ]
+				], { headingRows: 1 } ) );
 
-		it( 'should work with adding table rows at the beginning of a table', () => {
-			setModelData( model, modelTable( [
-				[ '00', '01' ],
-				[ '10', '11' ]
-			], { headingRows: 1 } ) );
+				const table = root.getChild( 0 );
 
-			const table = root.getChild( 0 );
+				model.change( writer => {
+					writer.setAttribute( 'headingRows', 2, table );
 
-			model.change( writer => {
-				writer.setAttribute( 'headingRows', 2, table );
+					const tableRow = writer.createElement( 'tableRow' );
 
-				const tableRow = writer.createElement( 'tableRow' );
+					writer.insert( tableRow, table, 0 );
+					writer.insertElement( 'tableCell', tableRow, 'end' );
+					writer.insertElement( 'tableCell', tableRow, 'end' );
+				} );
 
-				writer.insert( tableRow, table, 0 );
-				writer.insertElement( 'tableCell', tableRow, 'end' );
-				writer.insertElement( 'tableCell', tableRow, 'end' );
+				assertEqualMarkup( getViewData( view, { withoutSelection: true } ), viewTable( [
+					[ '', '' ],
+					[ '00', '01' ],
+					[ '10', '11' ]
+				], { headingRows: 2, asWidget: true } ) );
 			} );
 
-			assertEqualMarkup( getViewData( view, { withoutSelection: true } ), viewTable( [
-				[ '', '' ],
-				[ '00', '01' ],
-				[ '10', '11' ]
-			], { headingRows: 2 } ) );
-		} );
+			it( 'should work with adding a table row and expanding heading', () => {
+				setModelData( model, modelTable( [
+					[ '00', '01' ],
+					[ '10', '11' ],
+					[ '20', '21' ]
+				], { headingRows: 1 } ) );
 
-		it( 'should work with adding a table row and expanding heading', () => {
-			setModelData( model, modelTable( [
-				[ '00', '01' ],
-				[ '10', '11' ],
-				[ '20', '21' ]
-			], { headingRows: 1 } ) );
+				const table = root.getChild( 0 );
 
-			const table = root.getChild( 0 );
+				model.change( writer => {
+					writer.setAttribute( 'headingRows', 2, table );
 
-			model.change( writer => {
-				writer.setAttribute( 'headingRows', 2, table );
+					const tableRow = writer.createElement( 'tableRow' );
 
-				const tableRow = writer.createElement( 'tableRow' );
+					writer.insert( tableRow, table, 1 );
+					writer.insertElement( 'tableCell', tableRow, 'end' );
+					writer.insertElement( 'tableCell', tableRow, 'end' );
+				} );
 
-				writer.insert( tableRow, table, 1 );
-				writer.insertElement( 'tableCell', tableRow, 'end' );
-				writer.insertElement( 'tableCell', tableRow, 'end' );
-			} );
-
-			assertEqualMarkup( getViewData( view, { withoutSelection: true } ), viewTable( [
-				[ '00', '01' ],
-				[ '', '' ],
-				[ '10', '11' ],
-				[ '20', '21' ]
-			], { headingRows: 2 } ) );
-		} );
-
-		describe( 'options.asWidget=true', () => {
-			beforeEach( () => {
-				return VirtualTestEditor.create()
-					.then( newEditor => {
-						editor = newEditor;
-						model = editor.model;
-						doc = model.document;
-						root = doc.getRoot( 'main' );
-						view = editor.editing.view;
-
-						defaultSchema( model.schema );
-						defaultConversion( editor.conversion, true );
-					} );
+				assertEqualMarkup( getViewData( view, { withoutSelection: true } ), viewTable( [
+					[ '00', '01' ],
+					[ '', '' ],
+					[ '10', '11' ],
+					[ '20', '21' ]
+				], { headingRows: 2, asWidget: true } ) );
 			} );
 
 			it( 'should create renamed cell as a widget', () => {
@@ -1201,7 +1194,7 @@ describe( 'downcast converters', () => {
 	} );
 
 	describe( 'downcastRemoveRow()', () => {
-		// The beforeEach is duplicated due to ckeditor/ckeditor5#6574. New test are written using TableEdting.
+		// The beforeEach is duplicated due to ckeditor/ckeditor5#6574. New test are written using TableEditing.
 		beforeEach( async () => {
 			// Most tests assume non-edge environment but we do not set `contenteditable=false` on Edge so stub `env.isEdge`.
 			testUtils.sinon.stub( env, 'isEdge' ).get( () => false );

--- a/tests/converters/downcast.js
+++ b/tests/converters/downcast.js
@@ -952,16 +952,16 @@ describe( 'downcast converters', () => {
 
 				assertEqualMarkup( getViewData( view, { withoutSelection: true } ),
 					'<figure class="ck-widget ck-widget_with-selection-handle table" contenteditable="false">' +
-					'<div class="ck ck-widget__selection-handle"></div>' +
-					'<table>' +
-					'<thead>' +
-					'<tr>' +
-					'<th class="ck-editor__editable ck-editor__nested-editable" contenteditable="true">' +
-					'<span style="display:inline-block">00</span>' +
-					'</th>' +
-					'</tr>' +
-					'</thead>' +
-					'</table>' +
+						'<div class="ck ck-widget__selection-handle"></div>' +
+						'<table>' +
+							'<thead>' +
+								'<tr>' +
+									'<th class="ck-editor__editable ck-editor__nested-editable" contenteditable="true">' +
+										'<span style="display:inline-block">00</span>' +
+									'</th>' +
+								'</tr>' +
+							'</thead>' +
+						'</table>' +
 					'</figure>'
 				);
 			} );

--- a/tests/tableutils.js
+++ b/tests/tableutils.js
@@ -938,7 +938,7 @@ describe( 'TableUtils', () => {
 				] ) );
 			} );
 
-			it( 'should create one undo step (1 batch)', () => {
+			it( 'should re-use batch to create one undo step', () => {
 				setData( model, modelTable( [
 					[ '00', '01' ],
 					[ '10', '11' ],
@@ -954,7 +954,9 @@ describe( 'TableUtils', () => {
 					createdBatches.add( operation.batch );
 				} );
 
-				tableUtils.removeRows( root.getChild( 0 ), { at: 0, rows: 2 } );
+				const batch = model.createBatch();
+
+				tableUtils.removeRows( root.getChild( 0 ), { at: 0, rows: 2, batch } );
 
 				expect( createdBatches.size ).to.equal( 1 );
 			} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Removing the last header row no longer breaks the table in the editing view. Closes ckeditor/ckeditor5#6437.

---

### Additional information

~The actual fix is in 242a2e0 commit. It turned out that the tests weren't written in the same way as row removing is implemented (df80eec).~ Removing row from a header section involves changing `headingRows` attribute on a table.

The rest of the changes in tests was done due to ckeditor/ckeditor5#6574.