### PR TITLE
I/6502: Refactor TableUtils.removeRows() logic.

### DIFF
--- a/src/tableutils.js
+++ b/src/tableutils.js
@@ -311,7 +311,7 @@ export default class TableUtils extends Plugin {
 			const isCellOverlappingRemovedRows = row < first && lastRowOfCell >= first;
 
 			if ( isCellOverlappingRemovedRows ) {
-				const rowspanAdjustment = lastRowOfCell >= last ? rowsToRemove : first - row;
+				const rowspanAdjustment = lastRowOfCell >= last ? rowsToRemove : lastRowOfCell - first + 1;
 				const rowSpanToSet = rowspan - rowspanAdjustment;
 				cellsToTrim.push( { cell, rowspan: rowSpanToSet } );
 			}

--- a/src/tableutils.js
+++ b/src/tableutils.js
@@ -766,7 +766,7 @@ function updateHeadingRows( table, first, last, model, batch ) {
 }
 
 // Finds cells that will be:
-// - trimmed - Cells that are "above" removed rows sections and overlaps removed section - their rowspan must be trimmed.
+// - trimmed - Cells that are "above" removed rows sections and overlap the removed section - their rowspan must be trimmed.
 // - moved - Cells from removed rows section might stick out of. Such cells are moved to a next row after a removed section.
 //
 // Sample table with overlapping & sticking out cells:

--- a/src/tableutils.js
+++ b/src/tableutils.js
@@ -305,7 +305,7 @@ export default class TableUtils extends Plugin {
 				writer.remove( table.getChild( i ) );
 			}
 
-			// 2c. Update cells from rows above that overlaps removed section. Similar to step 2 but does not involve moving cells.
+			// 2c. Update cells from rows above that overlap removed section. Similar to step 2 but does not involve moving cells.
 			for ( const { rowspan, cell } of cellsToTrim ) {
 				updateNumericAttribute( 'rowspan', rowspan, cell, writer );
 			}

--- a/src/tableutils.js
+++ b/src/tableutils.js
@@ -267,9 +267,9 @@ export default class TableUtils extends Plugin {
 	 *		    ┌───┬───┬───┐        `at` = 1        ┌───┬───┬───┐
 	 *		  0 │ a │ b │ c │        `rows` = 2      │ a │ b │ c │ 0
 	 *		    │   ├───┼───┤                        │   ├───┼───┤
-	 *		  1 │   │ d │ e │  <-- remove from here  │   │ d │ i │ 1
+	 *		  1 │   │ d │ e │  <-- remove from here  │   │ d │ g │ 1
 	 *		    │   │   ├───┤        will give:      ├───┼───┼───┤
-	 *		  2 │   │   │ f │                        │ j │ k │ l │ 2
+	 *		  2 │   │   │ f │                        │ h │ i │ j │ 2
 	 *		    │   │   ├───┤                        └───┴───┴───┘
 	 *		  3 │   │   │ g │
 	 *		    ├───┼───┼───┤

--- a/src/tableutils.js
+++ b/src/tableutils.js
@@ -795,11 +795,13 @@ function moveCellsToRow( table, targetRowIndex, cellsToMove, writer ) {
 		startRow: targetRowIndex,
 		endRow: targetRowIndex
 	} );
+
+	const tableRowMap = [ ...tableWalker ];
 	const row = table.getChild( targetRowIndex );
 
 	let previousCell;
 
-	for ( const { column, cell, isSpanned } of tableWalker ) {
+	for ( const { column, cell, isSpanned } of tableRowMap ) {
 		if ( cellsToMove.has( column ) ) {
 			const { cell: cellToMove, rowspan } = cellsToMove.get( column );
 

--- a/src/tableutils.js
+++ b/src/tableutils.js
@@ -291,7 +291,7 @@ export default class TableUtils extends Plugin {
 		// Removing rows from table requires most calculations to be done prior to changing table structure.
 
 		// 1. Preparation - get row-spanned cells that have to be modified after removing rows.
-		const { cellsToMove, cellsToTrim } = getCellsToMoveAndTrimOnRemoveRow( table, last, first, rowsToRemove );
+		const { cellsToMove, cellsToTrim } = getCellsToMoveAndTrimOnRemoveRow( table, first, last );
 
 		// 2. Execution
 		model.change( writer => {
@@ -786,7 +786,7 @@ function updateHeadingRows( table, first, last, model, batch ) {
 // In a table above:
 // - cells to trim: '02', '03' & '04'.
 // - cells to move: '21' & '32'.
-function getCellsToMoveAndTrimOnRemoveRow( table, last, first, rowsToRemove ) {
+function getCellsToMoveAndTrimOnRemoveRow( table, first, last ) {
 	const cellsToMove = new Map();
 	const cellsToTrim = [];
 
@@ -812,7 +812,7 @@ function getCellsToMoveAndTrimOnRemoveRow( table, last, first, rowsToRemove ) {
 
 			// Cell fully covers removed section - trim it by removed rows count.
 			if ( lastRowOfCell >= last ) {
-				rowspanAdjustment = rowsToRemove;
+				rowspanAdjustment = last - first + 1;
 			}
 			// Cell partially overlaps removed section - calculate cell's span that is in removed section.
 			else {

--- a/src/tableutils.js
+++ b/src/tableutils.js
@@ -767,7 +767,7 @@ function updateHeadingRows( table, first, last, model, batch ) {
 
 // Finds cells that will be:
 // - trimmed - Cells that are "above" removed rows sections and overlap the removed section - their rowspan must be trimmed.
-// - moved - Cells from removed rows section might stick out of. Such cells are moved to a next row after a removed section.
+// - moved - Cells from removed rows section might stick out of. These cells are moved to the next row after a removed section.
 //
 // Sample table with overlapping & sticking out cells:
 //

--- a/tests/tableutils.js
+++ b/tests/tableutils.js
@@ -939,33 +939,37 @@ describe( 'TableUtils', () => {
 				] ) );
 			} );
 
-			it( 'should properly calculate truncated rowspans', () => {
+			it( 'should move row-spaned cells to a row after removed rows section', () => {
 				setData( model, modelTable( [
-					[ '00', { contents: '01', rowspan: 3 } ],
-					[ '10' ],
-					[ '20' ]
-				] ) );
-
-				tableUtils.removeRows( root.getChild( 0 ), { at: 0, rows: 2 } );
-
-				assertEqualMarkup( getData( model, { withoutSelection: true } ), modelTable( [
-					[ '20', '01' ]
-				] ) );
-			} );
-
-			it( 'should decrease rowspan of table cells from rows before removed rows section', () => {
-				setData( model, modelTable( [
-					[ { rowspan: 4, contents: '00' }, { rowspan: 3, contents: '01' }, { rowspan: 2, contents: '02' }, '03', '04' ],
-					[ '13', '14' ],
-					[ '22', '23', '24' ],
-					[ '31', '32', '33', '34' ]
+					[ '00', '01', '02', '03' ],
+					[ { rowspan: 4, contents: '10' }, { rowspan: 3, contents: '11' }, { rowspan: 2, contents: '12' }, '13' ],
+					[ '23' ],
+					[ '32', '33' ],
+					[ '41', '42', '43' ]
 				] ) );
 
 				tableUtils.removeRows( root.getChild( 0 ), { at: 1, rows: 2 } );
 
 				assertEqualMarkup( getData( model, { withoutSelection: true } ), modelTable( [
-					[ { rowspan: 2, contents: '00' }, '01', '02', '03', '04' ],
-					[ '31', '32', '33', '34' ]
+					[ '00', '01', '02', '03' ],
+					[ { rowspan: 2, contents: '10' }, '11', '32', '33' ],
+					[ '41', '42', '43' ]
+				] ) );
+			} );
+
+			it( 'should decrease rowspan of table cells from rows before removed rows section', () => {
+				setData( model, modelTable( [
+					[ { rowspan: 4, contents: '00' }, { rowspan: 3, contents: '01' }, { rowspan: 2, contents: '02' }, '03' ],
+					[ '13' ],
+					[ '22', '23' ],
+					[ '31', '32', '33' ]
+				] ) );
+
+				tableUtils.removeRows( root.getChild( 0 ), { at: 1, rows: 2 } );
+
+				assertEqualMarkup( getData( model, { withoutSelection: true } ), modelTable( [
+					[ { rowspan: 2, contents: '00' }, '01', '02', '03' ],
+					[ '31', '32', '33' ]
 				] ) );
 			} );
 

--- a/tests/tableutils.js
+++ b/tests/tableutils.js
@@ -905,6 +905,52 @@ describe( 'TableUtils', () => {
 			} );
 
 			it( 'should decrease rowspan of table cells from previous rows', () => {
+				// +----+----+----+----+----+
+				// | 00 | 01 | 02 | 03 | 04 |
+				// +----+    +    +    +    +
+				// | 10 |    |    |    |    |
+				// +----+----+    +    +    +
+				// | 20 | 21 |    |    |    |
+				// +----+----+----+    +    +
+				// | 30 | 31 | 32 |    |    |
+				// +----+----+----+----+    +
+				// | 40 | 41 | 42 | 43 |    |
+				// +----+----+----+----+----+
+				// | 50 | 51 | 52 | 53 | 44 |
+				// +----+----+----+----+----+
+				setData( model, modelTable( [
+					[ '00', { contents: '01', rowspan: 2 }, { contents: '02', rowspan: 3 }, { contents: '03', rowspan: 4 },
+						{ contents: '04', rowspan: 5 } ],
+					[ '10' ],
+					[ '20', '21' ],
+					[ '30', '31', '32' ],
+					[ '40', '41', '42', '43' ],
+					[ '50', '51', '52', '53', '54' ]
+				] ) );
+
+				tableUtils.removeRows( root.getChild( 0 ), { at: 1, rows: 1 } );
+
+				// +----+----+----+----+----+
+				// | 00 | 01 | 02 | 03 | 04 |
+				// +----+----+    +    +    +
+				// | 20 | 21 |    |    |    |
+				// +----+----+----+    +    +
+				// | 30 | 31 | 32 |    |    |
+				// +----+----+----+----+    +
+				// | 40 | 41 | 42 | 43 |    |
+				// +----+----+----+----+----+
+				// | 50 | 51 | 52 | 53 | 44 |
+				// +----+----+----+----+----+
+				assertEqualMarkup( getData( model, { withoutSelection: true } ), modelTable( [
+					[ '00', '01', { contents: '02', rowspan: 2 }, { contents: '03', rowspan: 3 }, { contents: '04', rowspan: 4 } ],
+					[ '20', '21' ],
+					[ '30', '31', '32' ],
+					[ '40', '41', '42', '43' ],
+					[ '50', '51', '52', '53', '54' ]
+				] ) );
+			} );
+
+			it( 'should decrease rowspan of table cells from previous rows (rowspaned cells on different rows)', () => {
 				setData( model, modelTable( [
 					[ { rowspan: 4, contents: '00' }, { rowspan: 3, contents: '01' }, { rowspan: 2, contents: '02' }, '03', '04' ],
 					[ { rowspan: 2, contents: '13' }, '14' ],
@@ -1081,6 +1127,48 @@ describe( 'TableUtils', () => {
 				assertEqualMarkup( getData( model, { withoutSelection: true } ), modelTable( [
 					[ { rowspan: 2, contents: '00' }, '01', '02', '03' ],
 					[ '31', '32', '33' ]
+				] ) );
+			} );
+
+			it( 'should decrease rowspan of table cells from previous rows', () => {
+				// +----+----+----+----+----+
+				// | 00 | 01 | 02 | 03 | 04 |
+				// +----+    +    +    +    +
+				// | 10 |    |    |    |    |
+				// +----+----+    +    +    +
+				// | 20 | 21 |    |    |    |
+				// +----+----+----+    +    +
+				// | 30 | 31 | 32 |    |    |
+				// +----+----+----+----+    +
+				// | 40 | 41 | 42 | 43 |    |
+				// +----+----+----+----+----+
+				// | 50 | 51 | 52 | 53 | 44 |
+				// +----+----+----+----+----+
+				setData( model, modelTable( [
+					[ '00', { contents: '01', rowspan: 2 }, { contents: '02', rowspan: 3 }, { contents: '03', rowspan: 4 },
+						{ contents: '04', rowspan: 5 } ],
+					[ '10' ],
+					[ '20', '21' ],
+					[ '30', '31', '32' ],
+					[ '40', '41', '42', '43' ],
+					[ '50', '51', '52', '53', '54' ]
+				] ) );
+
+				tableUtils.removeRows( root.getChild( 0 ), { at: 2, rows: 2 } );
+
+				// +----+----+----+----+----+
+				// | 00 | 01 | 02 | 03 | 04 |
+				// +----+    +    +    +    +
+				// | 10 |    |    |    |    |
+				// +----+----+----+----+    +
+				// | 40 | 41 | 42 | 43 |    |
+				// +----+----+----+----+----+
+				assertEqualMarkup( getData( model, { withoutSelection: true } ), modelTable( [
+					[ '00', { contents: '01', rowspan: 2 }, { contents: '02', rowspan: 2 }, { contents: '03', rowspan: 2 },
+						{ contents: '04', rowspan: 3 } ],
+					[ '10' ],
+					[ '40', '41', '42', '43' ],
+					[ '50', '51', '52', '53', '54' ]
 				] ) );
 			} );
 

--- a/tests/tableutils.js
+++ b/tests/tableutils.js
@@ -1142,7 +1142,7 @@ describe( 'TableUtils', () => {
 				// +----+----+----+----+    +
 				// | 40 | 41 | 42 | 43 |    |
 				// +----+----+----+----+----+
-				// | 50 | 51 | 52 | 53 | 44 |
+				// | 50 | 51 | 52 | 53 | 54 |
 				// +----+----+----+----+----+
 				setData( model, modelTable( [
 					[ '00', { contents: '01', rowspan: 2 }, { contents: '02', rowspan: 3 }, { contents: '03', rowspan: 4 },
@@ -1162,6 +1162,8 @@ describe( 'TableUtils', () => {
 				// | 10 |    |    |    |    |
 				// +----+----+----+----+    +
 				// | 40 | 41 | 42 | 43 |    |
+				// +----+----+----+----+----+
+				// | 50 | 51 | 52 | 53 | 54 |
 				// +----+----+----+----+----+
 				assertEqualMarkup( getData( model, { withoutSelection: true } ), modelTable( [
 					[ '00', { contents: '01', rowspan: 2 }, { contents: '02', rowspan: 2 }, { contents: '03', rowspan: 2 },

--- a/tests/tableutils.js
+++ b/tests/tableutils.js
@@ -743,7 +743,7 @@ describe( 'TableUtils', () => {
 			] ) );
 		} );
 
-		it( 'should split rowspanned & colspaned cell', () => {
+		it( 'should split rowspanned & colspanned cell', () => {
 			setData( model, modelTable( [
 				[ '00', { colspan: 2, contents: '01[]' } ],
 				[ '10', '11' ]
@@ -950,7 +950,7 @@ describe( 'TableUtils', () => {
 				] ) );
 			} );
 
-			it( 'should decrease rowspan of table cells from previous rows (rowspaned cells on different rows)', () => {
+			it( 'should decrease rowspan of table cells from previous rows (row-spanned cells on different rows)', () => {
 				setData( model, modelTable( [
 					[ { rowspan: 4, contents: '00' }, { rowspan: 3, contents: '01' }, { rowspan: 2, contents: '02' }, '03', '04' ],
 					[ { rowspan: 2, contents: '13' }, '14' ],
@@ -967,7 +967,7 @@ describe( 'TableUtils', () => {
 				] ) );
 			} );
 
-			it( 'should move rowspaned cells to a row below removing it\'s row', () => {
+			it( 'should move row-spanned cells to a row below removing it\'s row', () => {
 				setData( model, modelTable( [
 					[ { rowspan: 3, contents: '00' }, { rowspan: 2, contents: '01' }, '02' ],
 					[ '12' ],
@@ -984,7 +984,7 @@ describe( 'TableUtils', () => {
 				] ) );
 			} );
 
-			it( 'should move rowspaned cells to a row below removing it\'s row (other cell is overlapping removed row)', () => {
+			it( 'should move row-spanned cells to a row below removing it\'s row (other cell is overlapping removed row)', () => {
 				setData( model, modelTable( [
 					[ '00', { rowspan: 3, contents: '01' }, '02', '03', '04' ],
 					[ '10', { rowspan: 2, contents: '12' }, '13', '14' ],
@@ -1096,7 +1096,7 @@ describe( 'TableUtils', () => {
 				] ) );
 			} );
 
-			it( 'should move row-spaned cells to a row after removed rows section', () => {
+			it( 'should move row-spanned cells to a row after removed rows section', () => {
 				setData( model, modelTable( [
 					[ '00', '01', '02', '03' ],
 					[ { rowspan: 4, contents: '10' }, { rowspan: 3, contents: '11' }, { rowspan: 2, contents: '12' }, '13' ],

--- a/tests/tableutils.js
+++ b/tests/tableutils.js
@@ -8,37 +8,53 @@ import { getData, setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model
 
 import { defaultConversion, defaultSchema, modelTable } from './_utils/utils';
 
+import TableEditing from '../src/tableediting';
 import TableUtils from '../src/tableutils';
 import { assertEqualMarkup } from '@ckeditor/ckeditor5-utils/tests/_utils/utils';
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 
 describe( 'TableUtils', () => {
 	let editor, model, root, tableUtils;
-
-	beforeEach( () => {
-		return ModelTestEditor.create( {
-			plugins: [ TableUtils ]
-		} ).then( newEditor => {
-			editor = newEditor;
-			model = editor.model;
-			root = model.document.getRoot( 'main' );
-			tableUtils = editor.plugins.get( TableUtils );
-
-			defaultSchema( model.schema );
-			defaultConversion( editor.conversion );
-		} );
-	} );
 
 	afterEach( () => {
 		return editor.destroy();
 	} );
 
 	describe( '#pluginName', () => {
+		beforeEach( () => {
+			return ModelTestEditor.create( {
+				plugins: [ TableUtils ]
+			} ).then( newEditor => {
+				editor = newEditor;
+				model = editor.model;
+				root = model.document.getRoot( 'main' );
+				tableUtils = editor.plugins.get( TableUtils );
+
+				defaultSchema( model.schema );
+				defaultConversion( editor.conversion );
+			} );
+		} );
+
 		it( 'should provide plugin name', () => {
 			expect( TableUtils.pluginName ).to.equal( 'TableUtils' );
 		} );
 	} );
 
 	describe( 'getCellLocation()', () => {
+		beforeEach( () => {
+			return ModelTestEditor.create( {
+				plugins: [ TableUtils ]
+			} ).then( newEditor => {
+				editor = newEditor;
+				model = editor.model;
+				root = model.document.getRoot( 'main' );
+				tableUtils = editor.plugins.get( TableUtils );
+
+				defaultSchema( model.schema );
+				defaultConversion( editor.conversion );
+			} );
+		} );
+
 		it( 'should return proper table cell location', () => {
 			setData( model, modelTable( [
 				[ { rowspan: 2, colspan: 2, contents: '00[]' }, '02' ],
@@ -52,6 +68,20 @@ describe( 'TableUtils', () => {
 	} );
 
 	describe( 'insertRows()', () => {
+		beforeEach( () => {
+			return ModelTestEditor.create( {
+				plugins: [ TableUtils ]
+			} ).then( newEditor => {
+				editor = newEditor;
+				model = editor.model;
+				root = model.document.getRoot( 'main' );
+				tableUtils = editor.plugins.get( TableUtils );
+
+				defaultSchema( model.schema );
+				defaultConversion( editor.conversion );
+			} );
+		} );
+
 		it( 'should insert row in given table at given index', () => {
 			setData( model, modelTable( [
 				[ '11[]', '12' ],
@@ -192,6 +222,20 @@ describe( 'TableUtils', () => {
 	} );
 
 	describe( 'insertColumns()', () => {
+		beforeEach( () => {
+			return ModelTestEditor.create( {
+				plugins: [ TableUtils ]
+			} ).then( newEditor => {
+				editor = newEditor;
+				model = editor.model;
+				root = model.document.getRoot( 'main' );
+				tableUtils = editor.plugins.get( TableUtils );
+
+				defaultSchema( model.schema );
+				defaultConversion( editor.conversion );
+			} );
+		} );
+
 		it( 'should insert column in given table at given index', () => {
 			setData( model, modelTable( [
 				[ '11[]', '12' ],
@@ -390,6 +434,20 @@ describe( 'TableUtils', () => {
 	} );
 
 	describe( 'splitCellVertically()', () => {
+		beforeEach( () => {
+			return ModelTestEditor.create( {
+				plugins: [ TableUtils ]
+			} ).then( newEditor => {
+				editor = newEditor;
+				model = editor.model;
+				root = model.document.getRoot( 'main' );
+				tableUtils = editor.plugins.get( TableUtils );
+
+				defaultSchema( model.schema );
+				defaultConversion( editor.conversion );
+			} );
+		} );
+
 		it( 'should split table cell to given table cells number', () => {
 			setData( model, modelTable( [
 				[ '00', '01', '02' ],
@@ -534,6 +592,20 @@ describe( 'TableUtils', () => {
 	} );
 
 	describe( 'splitCellHorizontally()', () => {
+		beforeEach( () => {
+			return ModelTestEditor.create( {
+				plugins: [ TableUtils ]
+			} ).then( newEditor => {
+				editor = newEditor;
+				model = editor.model;
+				root = model.document.getRoot( 'main' );
+				tableUtils = editor.plugins.get( TableUtils );
+
+				defaultSchema( model.schema );
+				defaultConversion( editor.conversion );
+			} );
+		} );
+
 		it( 'should split table cell to default table cells number', () => {
 			setData( model, modelTable( [
 				[ '00', '01', '02' ],
@@ -709,6 +781,20 @@ describe( 'TableUtils', () => {
 	} );
 
 	describe( 'getColumns()', () => {
+		beforeEach( () => {
+			return ModelTestEditor.create( {
+				plugins: [ TableUtils ]
+			} ).then( newEditor => {
+				editor = newEditor;
+				model = editor.model;
+				root = model.document.getRoot( 'main' );
+				tableUtils = editor.plugins.get( TableUtils );
+
+				defaultSchema( model.schema );
+				defaultConversion( editor.conversion );
+			} );
+		} );
+
 		it( 'should return proper number of columns', () => {
 			setData( model, modelTable( [
 				[ '00', { colspan: 3, contents: '01' }, '04' ]
@@ -719,6 +805,20 @@ describe( 'TableUtils', () => {
 	} );
 
 	describe( 'getRows()', () => {
+		beforeEach( () => {
+			return ModelTestEditor.create( {
+				plugins: [ TableUtils ]
+			} ).then( newEditor => {
+				editor = newEditor;
+				model = editor.model;
+				root = model.document.getRoot( 'main' );
+				tableUtils = editor.plugins.get( TableUtils );
+
+				defaultSchema( model.schema );
+				defaultConversion( editor.conversion );
+			} );
+		} );
+
 		it( 'should return proper number of columns for simple table', () => {
 			setData( model, modelTable( [
 				[ '00', '01' ],
@@ -749,6 +849,17 @@ describe( 'TableUtils', () => {
 	} );
 
 	describe( 'removeRows()', () => {
+		beforeEach( () => {
+			return ModelTestEditor.create( {
+				plugins: [ Paragraph, TableEditing, TableUtils ]
+			} ).then( newEditor => {
+				editor = newEditor;
+				model = editor.model;
+				root = model.document.getRoot( 'main' );
+				tableUtils = editor.plugins.get( TableUtils );
+			} );
+		} );
+
 		describe( 'single row', () => {
 			it( 'should remove a given row from a table start', () => {
 				setData( model, modelTable( [
@@ -797,7 +908,7 @@ describe( 'TableUtils', () => {
 				setData( model, modelTable( [
 					[ { rowspan: 4, contents: '00' }, { rowspan: 3, contents: '01' }, { rowspan: 2, contents: '02' }, '03', '04' ],
 					[ { rowspan: 2, contents: '13' }, '14' ],
-					[ '22', '23', '24' ],
+					[ '22', '24' ],
 					[ '31', '32', '33', '34' ]
 				] ) );
 
@@ -997,6 +1108,20 @@ describe( 'TableUtils', () => {
 	} );
 
 	describe( 'removeColumns()', () => {
+		beforeEach( () => {
+			return ModelTestEditor.create( {
+				plugins: [ TableUtils ]
+			} ).then( newEditor => {
+				editor = newEditor;
+				model = editor.model;
+				root = model.document.getRoot( 'main' );
+				tableUtils = editor.plugins.get( TableUtils );
+
+				defaultSchema( model.schema );
+				defaultConversion( editor.conversion );
+			} );
+		} );
+
 		describe( 'single row', () => {
 			it( 'should remove a given column', () => {
 				setData( model, modelTable( [

--- a/tests/tableutils.js
+++ b/tests/tableutils.js
@@ -943,17 +943,17 @@ describe( 'TableUtils', () => {
 				setData( model, modelTable( [
 					[ '00', '01', '02', '03' ],
 					[ { rowspan: 4, contents: '10' }, { rowspan: 3, contents: '11' }, { rowspan: 2, contents: '12' }, '13' ],
-					[ '23' ],
-					[ '32', '33' ],
-					[ '41', '42', '43' ]
+					[ { rowspan: 3, contents: '23' } ],
+					[ '32' ],
+					[ '41', '42' ]
 				] ) );
 
 				tableUtils.removeRows( root.getChild( 0 ), { at: 1, rows: 2 } );
 
 				assertEqualMarkup( getData( model, { withoutSelection: true } ), modelTable( [
 					[ '00', '01', '02', '03' ],
-					[ { rowspan: 2, contents: '10' }, '11', '32', '33' ],
-					[ '41', '42', '43' ]
+					[ { rowspan: 2, contents: '10' }, '11', '32', { rowspan: 2, contents: '23' } ],
+					[ '41', '42' ]
 				] ) );
 			} );
 

--- a/tests/tableutils.js
+++ b/tests/tableutils.js
@@ -798,7 +798,7 @@ describe( 'TableUtils', () => {
 					[ { rowspan: 4, contents: '00' }, { rowspan: 3, contents: '01' }, { rowspan: 2, contents: '02' }, '03', '04' ],
 					[ { rowspan: 2, contents: '13' }, '14' ],
 					[ '22', '23', '24' ],
-					[ '30', '31', '32', '33', '34' ]
+					[ '31', '32', '33', '34' ]
 				] ) );
 
 				tableUtils.removeRows( root.getChild( 0 ), { at: 2 } );
@@ -806,7 +806,7 @@ describe( 'TableUtils', () => {
 				assertEqualMarkup( getData( model, { withoutSelection: true } ), modelTable( [
 					[ { rowspan: 3, contents: '00' }, { rowspan: 2, contents: '01' }, { rowspan: 2, contents: '02' }, '03', '04' ],
 					[ '13', '14' ],
-					[ '30', '31', '32', '33', '34' ]
+					[ '31', '32', '33', '34' ]
 				] ) );
 			} );
 
@@ -950,6 +950,22 @@ describe( 'TableUtils', () => {
 
 				assertEqualMarkup( getData( model, { withoutSelection: true } ), modelTable( [
 					[ '20', '01' ]
+				] ) );
+			} );
+
+			it( 'should decrease rowspan of table cells from rows before removed rows section', () => {
+				setData( model, modelTable( [
+					[ { rowspan: 4, contents: '00' }, { rowspan: 3, contents: '01' }, { rowspan: 2, contents: '02' }, '03', '04' ],
+					[ '13', '14' ],
+					[ '22', '23', '24' ],
+					[ '31', '32', '33', '34' ]
+				] ) );
+
+				tableUtils.removeRows( root.getChild( 0 ), { at: 1, rows: 2 } );
+
+				assertEqualMarkup( getData( model, { withoutSelection: true } ), modelTable( [
+					[ { rowspan: 2, contents: '00' }, '01', '02', '03', '04' ],
+					[ '31', '32', '33', '34' ]
 				] ) );
 			} );
 

--- a/tests/tableutils.js
+++ b/tests/tableutils.js
@@ -810,7 +810,7 @@ describe( 'TableUtils', () => {
 				] ) );
 			} );
 
-			it( 'should move rowspaned cells to row below removing it\'s row', () => {
+			it( 'should move rowspaned cells to a row below removing it\'s row', () => {
 				setData( model, modelTable( [
 					[ { rowspan: 3, contents: '00' }, { rowspan: 2, contents: '01' }, '02' ],
 					[ '12' ],
@@ -824,6 +824,21 @@ describe( 'TableUtils', () => {
 					[ { rowspan: 2, contents: '00' }, '01', '12' ],
 					[ '21', '22' ],
 					[ '30', '31', '32' ]
+				] ) );
+			} );
+
+			it( 'should move rowspaned cells to a row below removing it\'s row (other cell is overlapping removed row)', () => {
+				setData( model, modelTable( [
+					[ '00', { rowspan: 3, contents: '01' }, '02', '03', '04' ],
+					[ '10', { rowspan: 2, contents: '12' }, '13', '14' ],
+					[ '20', '23', '24' ]
+				] ) );
+
+				tableUtils.removeRows( root.getChild( 0 ), { at: 1 } );
+
+				assertEqualMarkup( getData( model, { withoutSelection: true } ), modelTable( [
+					[ '00', { rowspan: 2, contents: '01' }, '02', '03', '04' ],
+					[ '20', '12', '23', '24' ]
 				] ) );
 			} );
 		} );

--- a/tests/tableutils.js
+++ b/tests/tableutils.js
@@ -916,7 +916,7 @@ describe( 'TableUtils', () => {
 				// +----+----+----+----+    +
 				// | 40 | 41 | 42 | 43 |    |
 				// +----+----+----+----+----+
-				// | 50 | 51 | 52 | 53 | 44 |
+				// | 50 | 51 | 52 | 53 | 54 |
 				// +----+----+----+----+----+
 				setData( model, modelTable( [
 					[ '00', { contents: '01', rowspan: 2 }, { contents: '02', rowspan: 3 }, { contents: '03', rowspan: 4 },
@@ -939,7 +939,7 @@ describe( 'TableUtils', () => {
 				// +----+----+----+----+    +
 				// | 40 | 41 | 42 | 43 |    |
 				// +----+----+----+----+----+
-				// | 50 | 51 | 52 | 53 | 44 |
+				// | 50 | 51 | 52 | 53 | 54 |
 				// +----+----+----+----+----+
 				assertEqualMarkup( getData( model, { withoutSelection: true } ), modelTable( [
 					[ '00', '01', { contents: '02', rowspan: 2 }, { contents: '03', rowspan: 3 }, { contents: '04', rowspan: 4 } ],

--- a/tests/tableutils.js
+++ b/tests/tableutils.js
@@ -414,7 +414,7 @@ describe( 'TableUtils', () => {
 			], { headingColumns: 4 } ) );
 		} );
 
-		it( 'should properly insert column while table has rowspanned cells', () => {
+		it( 'should properly insert column while table has row-spanned cells', () => {
 			setData( model, modelTable( [
 				[ { rowspan: 4, contents: '00[]' }, { rowspan: 2, contents: '01' }, '02' ],
 				[ '12' ],
@@ -642,7 +642,7 @@ describe( 'TableUtils', () => {
 			] ) );
 		} );
 
-		it( 'should properly update rowspanned cells overlapping selected cell', () => {
+		it( 'should properly update row-spanned cells overlapping selected cell', () => {
 			setData( model, modelTable( [
 				[ { rowspan: 2, contents: '00' }, '01', { rowspan: 3, contents: '02' } ],
 				[ '[]11' ],
@@ -660,7 +660,7 @@ describe( 'TableUtils', () => {
 			] ) );
 		} );
 
-		it( 'should split rowspanned cell', () => {
+		it( 'should split row-spanned cell', () => {
 			setData( model, modelTable( [
 				[ '00', { rowspan: 2, contents: '01[]' } ],
 				[ '10' ],
@@ -678,7 +678,7 @@ describe( 'TableUtils', () => {
 			] ) );
 		} );
 
-		it( 'should copy colspan while splitting rowspanned cell', () => {
+		it( 'should copy colspan while splitting row-spanned cell', () => {
 			setData( model, modelTable( [
 				[ '00', { rowspan: 2, colspan: 2, contents: '01[]' } ],
 				[ '10' ],
@@ -724,7 +724,7 @@ describe( 'TableUtils', () => {
 			] ) );
 		} );
 
-		it( 'should split rowspanned cell and updated other cells rowspan when splitting to bigger number of cells', () => {
+		it( 'should split row-spanned cell and updated other cells rowspan when splitting to bigger number of cells', () => {
 			setData( model, modelTable( [
 				[ '00', { rowspan: 2, contents: '01[]' } ],
 				[ '10' ],
@@ -743,7 +743,7 @@ describe( 'TableUtils', () => {
 			] ) );
 		} );
 
-		it( 'should split rowspanned & colspanned cell', () => {
+		it( 'should split row-spanned & col-spanned cell', () => {
 			setData( model, modelTable( [
 				[ '00', { colspan: 2, contents: '01[]' } ],
 				[ '10', '11' ]
@@ -1324,7 +1324,7 @@ describe( 'TableUtils', () => {
 				] ) );
 			} );
 
-			it( 'should remove column if other column is rowspanned (last column)', () => {
+			it( 'should remove column if other column is row-spanned (last column)', () => {
 				setData( model, modelTable( [
 					[ '00', { rowspan: 2, contents: '01' } ],
 					[ '10' ]
@@ -1337,7 +1337,7 @@ describe( 'TableUtils', () => {
 				] ) );
 			} );
 
-			it( 'should remove column if other column is rowspanned (first column)', () => {
+			it( 'should remove column if other column is row-spanned (first column)', () => {
 				setData( model, modelTable( [
 					[ { rowspan: 2, contents: '00' }, '01' ],
 					[ '11' ]


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Remove row in complex tables now properly move cells from removed rows. Closes ckeditor/ckeditor5#6502.

---

### Additional information

This PR also includes fixes for some issues when not operating on `TableEditing` model (no post-fixer). https://github.com/ckeditor/ckeditor5/issues/6574.

The actual fix is commented below but to fix that I had to understand the logic once again. Thus refactoring to removing all rows at once (this bring also a benefit of fewer operations when removing more than one row.

As a side effect, I've fixed some of the `removeRows()` test as it operated on wrongly created table. See: https://github.com/ckeditor/ckeditor5/issues/6574.
