### PR TITLE
I/6569: Remove array sorting flaws from table code

### DIFF
--- a/src/commands/removecolumncommand.js
+++ b/src/commands/removecolumncommand.js
@@ -10,7 +10,8 @@
 import Command from '@ckeditor/ckeditor5-core/src/command';
 
 import TableWalker from '../tablewalker';
-import { getSelectionAffectedTableCells } from '../utils';
+import { getColumnIndexes, getSelectionAffectedTableCells } from '../utils';
+import { findAncestor } from './utils';
 
 /**
  * The remove column command.
@@ -32,15 +33,12 @@ export default class RemoveColumnCommand extends Command {
 		const firstCell = selectedCells[ 0 ];
 
 		if ( firstCell ) {
-			const table = firstCell.parent.parent;
+			const table = findAncestor( 'table', firstCell );
 			const tableColumnCount = this.editor.plugins.get( 'TableUtils' ).getColumns( table );
 
-			const tableMap = [ ...new TableWalker( table ) ];
-			const columnIndexes = tableMap.filter( entry => selectedCells.includes( entry.cell ) ).map( el => el.column ).sort();
-			const minColumnIndex = columnIndexes[ 0 ];
-			const maxColumnIndex = columnIndexes[ columnIndexes.length - 1 ];
+			const { first, last } = getColumnIndexes( selectedCells );
 
-			this.isEnabled = maxColumnIndex - minColumnIndex < ( tableColumnCount - 1 );
+			this.isEnabled = last - first < ( tableColumnCount - 1 );
 		} else {
 			this.isEnabled = false;
 		}

--- a/src/utils.js
+++ b/src/utils.js
@@ -183,10 +183,10 @@ export function getColumnIndexes( selectedCells ) {
 function getFirstLastIndexesObject( indexes ) {
 	const allIndexesSorted = indexes.sort( ( indexA, indexB ) => indexA - indexB );
 
-	const minColumnIndex = allIndexesSorted[ 0 ];
-	const maxColumnIndex = allIndexesSorted[ allIndexesSorted.length - 1 ];
+	const first = allIndexesSorted[ 0 ];
+	const last = allIndexesSorted[ allIndexesSorted.length - 1 ];
 
-	return { first: minColumnIndex, last: maxColumnIndex };
+	return { first, last };
 }
 
 function sortRanges( rangesIterator ) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,6 +9,7 @@
 
 import { isWidget, toWidget } from '@ckeditor/ckeditor5-widget/src/utils';
 import { findAncestor } from './commands/utils';
+import TableWalker from './tablewalker';
 
 /**
  * Converts a given {@link module:engine/view/element~Element} to a table widget:
@@ -146,16 +147,46 @@ export function getSelectionAffectedTableCells( selection ) {
  *
  *		console.log( `Selected rows ${ first } to ${ last }` );
  *
- * @package {Array.<module:engine/model/element~Element>}
+ * @param {Array.<module:engine/model/element~Element>}
  * @returns {Object} Returns an object with `first` and `last` table row indexes.
  */
 export function getRowIndexes( tableCells ) {
-	const allIndexesSorted = tableCells.map( cell => cell.parent.index ).sort();
+	const indexes = tableCells.map( cell => cell.parent.index );
 
-	return {
-		first: allIndexesSorted[ 0 ],
-		last: allIndexesSorted[ allIndexesSorted.length - 1 ]
-	};
+	return getFirstLastIndexesObject( indexes );
+}
+
+/**
+ * Returns a helper object with `first` and `last` column index contained in given `tableCells`.
+ *
+ *		const selectedTableCells = getSelectedTableCells( editor.model.document.selection );
+ *
+ *		const { first, last } = getColumnIndexes( selectedTableCells );
+ *
+ *		console.log( `Selected columns ${ first } to ${ last }` );
+ *
+ * @param {Array.<module:engine/model/element~Element>}
+ * @returns {Object} Returns an object with `first` and `last` table column indexes.
+ */
+export function getColumnIndexes( selectedCells ) {
+	const table = findAncestor( 'table', selectedCells[ 0 ] );
+	const tableMap = [ ...new TableWalker( table ) ];
+
+	const indexes = tableMap
+		.filter( entry => selectedCells.includes( entry.cell ) )
+		.map( entry => entry.column );
+
+	return getFirstLastIndexesObject( indexes );
+}
+
+// Helper method to get an object with `first` and `last` indexes from an unsorted array of indexes.
+function getFirstLastIndexesObject( indexes ) {
+	const allIndexesSorted = indexes.sort( ( indexA, indexB ) => indexA - indexB );
+
+	const minColumnIndex = allIndexesSorted[ 0 ];
+	const maxColumnIndex = allIndexesSorted[ allIndexesSorted.length - 1 ];
+
+	return { first: minColumnIndex, last: maxColumnIndex };
 }
 
 function sortRanges( rangesIterator ) {

--- a/tests/commands/mergecellscommand.js
+++ b/tests/commands/mergecellscommand.js
@@ -208,6 +208,35 @@ describe( 'MergeCellsCommand', () => {
 
 			expect( command.isEnabled ).to.be.false;
 		} );
+
+		it( 'should be false if more than 10 rows selected and some are in heading section', () => {
+			setData( model, modelTable( [
+				[ '0' ],
+				[ '1' ],
+				[ '2' ],
+				[ '3' ],
+				[ '4' ],
+				[ '5' ],
+				[ '6' ],
+				[ '7' ],
+				[ '8' ],
+				[ '9' ],
+				[ '10' ],
+				[ '11' ],
+				[ '12' ],
+				[ '13' ],
+				[ '14' ]
+			], { headingRows: 10 } ) );
+
+			const tableSelection = editor.plugins.get( TableSelection );
+			const modelRoot = model.document.getRoot();
+			tableSelection._setCellSelection(
+				modelRoot.getNodeByPath( [ 0, 1, 0 ] ),
+				modelRoot.getNodeByPath( [ 0, 12, 0 ] )
+			);
+
+			expect( command.isEnabled ).to.be.false;
+		} );
 	} );
 
 	describe( 'execute()', () => {

--- a/tests/commands/removecolumncommand.js
+++ b/tests/commands/removecolumncommand.js
@@ -86,6 +86,21 @@ describe( 'RemoveColumnCommand', () => {
 			expect( command.isEnabled ).to.be.false;
 		} );
 
+		it( 'should be false if all columns are selected - table with more than 10 columns (array sort bug)', () => {
+			setData( model, modelTable( [
+				[ '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12' ]
+			] ) );
+
+			const tableSelection = editor.plugins.get( TableSelection );
+			const modelRoot = model.document.getRoot();
+			tableSelection._setCellSelection(
+				modelRoot.getNodeByPath( [ 0, 0, 0 ] ),
+				modelRoot.getNodeByPath( [ 0, 0, 12 ] )
+			);
+
+			expect( command.isEnabled ).to.be.false;
+		} );
+
 		it( 'should be false if selection is outside a table', () => {
 			setData( model, '<paragraph>11[]</paragraph>' );
 

--- a/tests/commands/removerowcommand.js
+++ b/tests/commands/removerowcommand.js
@@ -105,6 +105,33 @@ describe( 'RemoveRowCommand', () => {
 
 			expect( command.isEnabled ).to.be.false;
 		} );
+
+		it( 'should be false if all the rows are selected - table with more than 10 rows (array sort bug)', () => {
+			setData( model, modelTable( [
+				[ '0' ],
+				[ '1' ],
+				[ '2' ],
+				[ '3' ],
+				[ '4' ],
+				[ '5' ],
+				[ '6' ],
+				[ '7' ],
+				[ '8' ],
+				[ '9' ],
+				[ '10' ],
+				[ '11' ],
+				[ '12' ]
+			] ) );
+
+			const tableSelection = editor.plugins.get( TableSelection );
+			const modelRoot = model.document.getRoot();
+			tableSelection._setCellSelection(
+				modelRoot.getNodeByPath( [ 0, 0, 0 ] ),
+				modelRoot.getNodeByPath( [ 0, 12, 0 ] )
+			);
+
+			expect( command.isEnabled ).to.be.false;
+		} );
 	} );
 
 	describe( 'execute()', () => {
@@ -338,6 +365,41 @@ describe( 'RemoveRowCommand', () => {
 				command.execute();
 
 				expect( createdBatches.size ).to.equal( 1 );
+			} );
+
+			it( 'should properly remove more than 10 rows selected (array sort bug)', () => {
+				setData( model, modelTable( [
+					[ '0' ],
+					[ '1' ],
+					[ '2' ],
+					[ '3' ],
+					[ '4' ],
+					[ '5' ],
+					[ '6' ],
+					[ '7' ],
+					[ '8' ],
+					[ '9' ],
+					[ '10' ],
+					[ '11' ],
+					[ '12' ],
+					[ '13' ],
+					[ '14' ]
+				] ) );
+
+				const tableSelection = editor.plugins.get( TableSelection );
+				const modelRoot = model.document.getRoot();
+				tableSelection._setCellSelection(
+					modelRoot.getNodeByPath( [ 0, 1, 0 ] ),
+					modelRoot.getNodeByPath( [ 0, 12, 0 ] )
+				);
+
+				command.execute();
+
+				assertEqualMarkup( getData( model, { withoutSelection: true } ), modelTable( [
+					[ '0' ],
+					[ '13' ],
+					[ '14' ]
+				] ) );
 			} );
 		} );
 

--- a/tests/commands/selectrowcommand.js
+++ b/tests/commands/selectrowcommand.js
@@ -422,6 +422,53 @@ describe( 'SelectRowCommand', () => {
 					[ 0, 0 ]
 				] );
 			} );
+
+			it( 'should properly select more than 10 rows selected (array sort bug)', () => {
+				setData( model, modelTable( [
+					[ '0', 'x' ],
+					[ '1', 'x' ],
+					[ '2', 'x' ],
+					[ '3', 'x' ],
+					[ '4', 'x' ],
+					[ '5', 'x' ],
+					[ '6', 'x' ],
+					[ '7', 'x' ],
+					[ '8', 'x' ],
+					[ '9', 'x' ],
+					[ '10', 'x' ],
+					[ '11', 'x' ],
+					[ '12', 'x' ],
+					[ '13', 'x' ],
+					[ '14', 'x' ]
+				] ) );
+
+				const tableSelection = editor.plugins.get( TableSelection );
+				const modelRoot = model.document.getRoot();
+				tableSelection._setCellSelection(
+					modelRoot.getNodeByPath( [ 0, 1, 0 ] ),
+					modelRoot.getNodeByPath( [ 0, 12, 0 ] )
+				);
+
+				command.execute();
+
+				assertSelectedCells( model, [
+					[ 0, 0 ], // '0'
+					[ 1, 1 ], // '1'
+					[ 1, 1 ], // '2'
+					[ 1, 1 ], // '3'
+					[ 1, 1 ], // '4'
+					[ 1, 1 ], // '5'
+					[ 1, 1 ], // '6'
+					[ 1, 1 ], // '7'
+					[ 1, 1 ], // '8'
+					[ 1, 1 ], // '9'
+					[ 1, 1 ], // '10'
+					[ 1, 1 ], // '11'
+					[ 1, 1 ], // '12'
+					[ 0, 0 ], // '13'
+					[ 0, 0 ] //  '14
+				] );
+			} );
 		} );
 
 		describe( 'with entire row selected', () => {

--- a/tests/commands/setheadercolumncommand.js
+++ b/tests/commands/setheadercolumncommand.js
@@ -364,6 +364,25 @@ describe( 'SetHeaderColumnCommand', () => {
 						[ 0, 1, 1, 0 ]
 					] );
 				} );
+
+				it( 'should set it correctly in table with more than 10 columns (array sort bug)', () => {
+					setData( model, modelTable( [
+						[ '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14' ]
+					] ) );
+
+					const tableSelection = editor.plugins.get( TableSelection );
+					const modelRoot = model.document.getRoot();
+					tableSelection._setCellSelection(
+						modelRoot.getNodeByPath( [ 0, 0, 2 ] ),
+						modelRoot.getNodeByPath( [ 0, 0, 13 ] )
+					);
+
+					command.execute();
+
+					assertEqualMarkup( getData( model, { withoutSelection: true } ), modelTable( [
+						[ '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14' ]
+					], { headingColumns: 14 } ) );
+				} );
 			} );
 		} );
 

--- a/tests/commands/setheaderrowcommand.js
+++ b/tests/commands/setheaderrowcommand.js
@@ -346,6 +346,100 @@ describe( 'SetHeaderRowCommand', () => {
 				] );
 			} );
 
+			it( 'should set it correctly in table with more than 10 columns (array sort bug)', () => {
+				setData( model, modelTable( [
+					[ '0', 'x' ],
+					[ '1', 'x' ],
+					[ '2', 'x' ],
+					[ '3', 'x' ],
+					[ '4', 'x' ],
+					[ '5', 'x' ],
+					[ '6', 'x' ],
+					[ '7', 'x' ],
+					[ '8', 'x' ],
+					[ '9', 'x' ],
+					[ '10', 'x' ],
+					[ '11', 'x' ],
+					[ '12', 'x' ],
+					[ '13', 'x' ],
+					[ '14', 'x' ]
+				] ) );
+
+				const tableSelection = editor.plugins.get( TableSelection );
+				const modelRoot = model.document.getRoot();
+				tableSelection._setCellSelection(
+					modelRoot.getNodeByPath( [ 0, 13, 0 ] ),
+					modelRoot.getNodeByPath( [ 0, 2, 0 ] )
+				);
+
+				command.execute();
+
+				assertEqualMarkup( getData( model, { withoutSelection: true } ), modelTable( [
+					[ '0', 'x' ],
+					[ '1', 'x' ],
+					[ '2', 'x' ],
+					[ '3', 'x' ],
+					[ '4', 'x' ],
+					[ '5', 'x' ],
+					[ '6', 'x' ],
+					[ '7', 'x' ],
+					[ '8', 'x' ],
+					[ '9', 'x' ],
+					[ '10', 'x' ],
+					[ '11', 'x' ],
+					[ '12', 'x' ],
+					[ '13', 'x' ],
+					[ '14', 'x' ]
+				], { headingRows: 14 } ) );
+			} );
+
+			it( 'should set it correctly in table with more than 10 columns (array sort bug, reversed selection)', () => {
+				setData( model, modelTable( [
+					[ '0', 'x' ],
+					[ '1', 'x' ],
+					[ '2', 'x' ],
+					[ '3', 'x' ],
+					[ '4', 'x' ],
+					[ '5', 'x' ],
+					[ '6', 'x' ],
+					[ '7', 'x' ],
+					[ '8', 'x' ],
+					[ '9', 'x' ],
+					[ '10', 'x' ],
+					[ '11', 'x' ],
+					[ '12', 'x' ],
+					[ '13', 'x' ],
+					[ '14', 'x' ]
+				] ) );
+
+				const tableSelection = editor.plugins.get( TableSelection );
+				const modelRoot = model.document.getRoot();
+				tableSelection._setCellSelection(
+					modelRoot.getNodeByPath( [ 0, 2, 0 ] ),
+					modelRoot.getNodeByPath( [ 0, 13, 1 ] )
+				);
+
+				command.execute();
+
+				assertEqualMarkup( getData( model, { withoutSelection: true } ), modelTable( [
+					[ '0', 'x' ],
+					[ '1', 'x' ],
+					[ '2', 'x' ],
+					[ '3', 'x' ],
+					[ '4', 'x' ],
+					[ '5', 'x' ],
+					[ '6', 'x' ],
+					[ '7', 'x' ],
+					[ '8', 'x' ],
+					[ '9', 'x' ],
+					[ '10', 'x' ],
+					[ '11', 'x' ],
+					[ '12', 'x' ],
+					[ '13', 'x' ],
+					[ '14', 'x' ]
+				], { headingRows: 14 } ) );
+			} );
+
 			it( 'should remove header rows in case of multiple cell selection', () => {
 				setData( model, modelTable( [
 					[ '00' ],

--- a/tests/commands/setheaderrowcommand.js
+++ b/tests/commands/setheaderrowcommand.js
@@ -368,8 +368,8 @@ describe( 'SetHeaderRowCommand', () => {
 				const tableSelection = editor.plugins.get( TableSelection );
 				const modelRoot = model.document.getRoot();
 				tableSelection._setCellSelection(
-					modelRoot.getNodeByPath( [ 0, 13, 0 ] ),
-					modelRoot.getNodeByPath( [ 0, 2, 0 ] )
+					modelRoot.getNodeByPath( [ 0, 2, 0 ] ),
+					modelRoot.getNodeByPath( [ 0, 13, 0 ] )
 				);
 
 				command.execute();
@@ -415,8 +415,8 @@ describe( 'SetHeaderRowCommand', () => {
 				const tableSelection = editor.plugins.get( TableSelection );
 				const modelRoot = model.document.getRoot();
 				tableSelection._setCellSelection(
-					modelRoot.getNodeByPath( [ 0, 2, 0 ] ),
-					modelRoot.getNodeByPath( [ 0, 13, 1 ] )
+					modelRoot.getNodeByPath( [ 0, 13, 0 ] ),
+					modelRoot.getNodeByPath( [ 0, 2, 1 ] )
 				);
 
 				command.execute();


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Introduce `getColumnIndexes()` helper method and properly handle index sorting. Closes ckeditor/ckeditor5#6569. Closes ckeditor/ckeditor5#6544.

---

### Additional information

I don't have a good idea for a merge message as this:

1.  Introduces `getColumnIndexes()` helper method.
2.  Fixes `getRownIndexes()` bug
3.  Fixes other bugs when sorting indexes.

The PR is too big but reviews are long :(