### PR TITLE
i/6631:  The "Merge cells" split button should always be enabled

### DIFF
--- a/src/tableui.js
+++ b/src/tableui.js
@@ -278,18 +278,9 @@ export default class TableUI extends Plugin {
 		dropdownView.buttonView.set( {
 			label,
 			icon,
-			tooltip: true
+			tooltip: true,
+			isEnabled: true
 		} );
-
-		// The main part of the split button is bound to the "mergeTableCells" command only.
-		dropdownView.bind( 'isEnabled' ).to( editor.commands.get( mergeCommandName ) );
-
-		// The split button dropdown must be **always** enabled and ready to open no matter the state
-		// of the "mergeTableCells" command. You may not be able to merge multiple cells but you may want
-		// to split them. This is also about mobile devices where multi–cell selection will never work
-		// (that's why "Merge cell right", "Merge cell down", etc. are still there in the first place).
-		dropdownView.buttonView.arrowView.unbind( 'isEnabled' );
-		dropdownView.buttonView.arrowView.isEnabled = true;
 
 		// Merge selected table cells when the main part of the split button is clicked.
 		this.listenTo( dropdownView.buttonView, 'execute', () => {

--- a/tests/tableui.js
+++ b/tests/tableui.js
@@ -386,9 +386,9 @@ describe( 'TableUI', () => {
 			expect( dropdown.buttonView ).to.be.instanceOf( SplitButtonView );
 		} );
 
-		it( 'should bind #isEnabled to the "mergeTableCells" command', () => {
+		it( 'should have #isEnabled always true regardless of the "mergeTableCells" command state', () => {
 			command.isEnabled = false;
-			expect( dropdown.isEnabled ).to.be.false;
+			expect( dropdown.isEnabled ).to.be.true;
 
 			command.isEnabled = true;
 			expect( dropdown.isEnabled ).to.be.true;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: The "Merge cells" split button should always be enabled to improve discoverability of tools in the dropdown. Closes ckeditor/ckeditor5#6631.
