### PR TITLE
i/6638: Add support for text alignment in the table header

### DIFF
--- a/theme/table.css
+++ b/theme/table.css
@@ -41,8 +41,7 @@
 }
 
 /* Text alignment of the table header should match the editor settings and override the native browser styling,
-when content is available outside the ediitor.
-See https://github.com/ckeditor/ckeditor5/issues/6638 */
+when content is available outside the ediitor. See https://github.com/ckeditor/ckeditor5/issues/6638 */
 .ck-content[dir="rtl"] .table th {
 	text-align: right;
 }

--- a/theme/table.css
+++ b/theme/table.css
@@ -39,3 +39,14 @@
 		}
 	}
 }
+
+/* Text alignment of the table header should match the editor settings and override the native browser styling,
+when content is available outside the ediitor.
+See https://github.com/ckeditor/ckeditor5/issues/6638 */
+.ck-content[dir="rtl"] .table th {
+	text-align: right;
+}
+
+.ck-content[dir="ltr"] .table th {
+	text-align: left;
+}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Added support for text alignment in the table header, based on the editor's `dir` attribute. Closes ckeditor/ckeditor5#6638.