### PR TITLE
i/6634: Fix model-selection-range-intersects error in undo after merging two table cells.

### DIFF
--- a/src/commands/mergecellscommand.js
+++ b/src/commands/mergecellscommand.js
@@ -47,6 +47,11 @@ export default class MergeCellsCommand extends Command {
 			// All cells will be merge into the first one.
 			const firstTableCell = selectedTableCells.shift();
 
+			// Set the selection in cell that other cells are being merged to prevent model-selection-range-intersects error in undo.
+			// See https://github.com/ckeditor/ckeditor5/issues/6634.
+			// May be fixed by: https://github.com/ckeditor/ckeditor5/issues/6639.
+			writer.setSelection( firstTableCell, 0 );
+
 			// Update target cell dimensions.
 			const { mergeWidth, mergeHeight } = getMergeDimensions( firstTableCell, selectedTableCells, tableUtils );
 			updateNumericAttribute( 'colspan', mergeWidth, firstTableCell, writer );

--- a/tests/tableselection-integration.js
+++ b/tests/tableselection-integration.js
@@ -24,6 +24,7 @@ import DomEventData from '@ckeditor/ckeditor5-engine/src/view/observer/domeventd
 import { getCode } from '@ckeditor/ckeditor5-utils/src/keyboard';
 import Input from '@ckeditor/ckeditor5-typing/src/input';
 import ViewText from '@ckeditor/ckeditor5-engine/src/view/text';
+import UndoEditing from '@ckeditor/ckeditor5-undo/src/undoediting';
 
 describe( 'TableSelection - integration', () => {
 	let editor, model, tableSelection, modelRoot, element, viewDocument;
@@ -218,6 +219,34 @@ describe( 'TableSelection - integration', () => {
 					'</tableRow>' +
 				'</table>'
 			);
+		} );
+	} );
+
+	describe( 'with undo', () => {
+		beforeEach( async () => {
+			await setupEditor( [ UndoEditing ] );
+		} );
+
+		// See https://github.com/ckeditor/ckeditor5/issues/6634.
+		it( 'works with merge cells command', () => {
+			setModelData( editor.model, modelTable( [ [ '00', '01' ] ] ) );
+
+			tableSelection._setCellSelection(
+				modelRoot.getNodeByPath( [ 0, 0, 0 ] ),
+				modelRoot.getNodeByPath( [ 0, 0, 1 ] )
+			);
+
+			editor.execute( 'mergeTableCells' );
+
+			assertEqualMarkup( getModelData( model ), modelTable( [
+				[ { colspan: 2, contents: '<paragraph>[00</paragraph><paragraph>01]</paragraph>' } ]
+			] ) );
+
+			editor.execute( 'undo' );
+
+			assertEqualMarkup( getModelData( model ), modelTable( [
+				[ '[]00', '01' ]
+			] ) );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Merge table cells now set selection in the merged cell before merging other cells into it. Closes ckeditor/ckeditor5#6634. See ckeditor/ckeditor5#6639.

---

### Additional information

*   This is a "work for now" fix because digging the cause of ckeditor/ckeditor5#6639 might take a while.
*   I'm not sure whether to close the original ticket or not. This issue is covered but not fixed.
*   The behaviour is also "wrong" - selection is restored as collapsed in the first table cell.